### PR TITLE
SPLITBEAT: the run never restarts, and a beginner can survive it

### DIFF
--- a/dynawalla/games/rhythm/src/dev/measure.ts
+++ b/dynawalla/games/rhythm/src/dev/measure.ts
@@ -1,0 +1,217 @@
+/**
+ * Survivability probe — QA only, never shipped, never imported by the game.
+ *
+ * Drives a real `Game` on the fake audio clock and reports the numbers the
+ * founder's report is about: how many seconds a given kind of player survives,
+ * how long they wait for the first question, and what the answering window is.
+ *
+ * Run: node --experimental-strip-types src/dev/measure.ts
+ */
+
+import { installFakeAudio } from "./fakeAudio.ts";
+
+const audio = installFakeAudio();
+const { Game } = await import("../game/core.ts");
+import type { Host } from "../contract.ts";
+import { answerPlan } from "../game/answer.ts";
+import { strikeWindows } from "../game/judge.ts";
+
+type Skill = "none" | "moderate" | "expert";
+
+/** Probability a player of this skill lands a given note, and their jitter. */
+const SKILL: Record<Skill, { p: number; jitterMs: number }> = {
+  none: { p: 0, jitterMs: 0 },
+  moderate: { p: 0.7, jitterMs: 55 },
+  expert: { p: 1, jitterMs: 8 },
+};
+
+function makeHost(log: { asked: number[]; reports: unknown[] }): Host {
+  let n = 0;
+  return {
+    next(opts) {
+      n += 1;
+      log.asked.push(opts?.difficulty ?? 0);
+      return {
+        id: `q${n}`,
+        prompt: `${n} + 3`,
+        answer: "4",
+        distractors: ["3", "6"],
+        domain: "add-sub",
+        difficulty: (opts?.difficulty ?? 1) / 10,
+      };
+    },
+    report(r) {
+      log.reports.push(r);
+    },
+    haptic() {},
+    prefersReducedMotion() {
+      return true;
+    },
+  };
+}
+
+function mulberry(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export type Probe = {
+  skill: Skill;
+  /** seconds of clock before the heart first ran out, or Infinity */
+  breakdownAt: number;
+  breakdowns: number;
+  firstQuestionAt: number;
+  questionGaps: number[];
+  /** answer window in seconds for each gate, in order */
+  answerWindows: number[];
+  /** timing window at each gate, in ms */
+  answerMissMs: number[];
+  difficultyAtGate: number[];
+  /** (item difficulty, delivered read seconds) for every gate */
+  itemVsWindow: [number, number][];
+  finalDifficulty: number;
+  notesMissed: number;
+  notesHit: number;
+  chartSignature: string[];
+};
+
+export async function probe(
+  skill: Skill,
+  seconds: number,
+  answer: "right" | "wrong" | "never" = "right",
+  seed = 7,
+): Promise<Probe> {
+  const log = { asked: [] as number[], reports: [] as unknown[] };
+  const game = new Game(makeHost(log));
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+  const rnd = mulberry(seed);
+  const cfg = SKILL[skill];
+
+  let breakdownAt = Infinity;
+  let breakdowns = 0;
+  let prevDebt = game.heartDebt;
+  let firstQuestionAt = Infinity;
+  const gateSeen = new Set<number>();
+  const questionAt: number[] = [];
+  const answerWindows: number[] = [];
+  const answerMissMs: number[] = [];
+  const difficultyAtGate: number[] = [];
+  const itemVsWindow: [number, number][] = [];
+  const chartSignature: string[] = [];
+  let sigBars = 0;
+
+  const steps = Math.round(seconds / 0.02);
+  for (let i = 0; i < steps; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    const now = ctx.currentTime;
+
+    if (!prevDebt && game.heartDebt) {
+      breakdowns++;
+      if (breakdownAt === Infinity) breakdownAt = now;
+    }
+    prevDebt = game.heartDebt;
+
+    for (const g of game.gates) {
+      if (!g.active || gateSeen.has(g.id)) continue;
+      // a gate is only measurable once its choice tiles exist
+      const tile = game.notes.find((n) => n.active && n.isChoice && n.gateId === g.id);
+      if (!tile) continue;
+      gateSeen.add(g.id);
+      questionAt.push(g.revealAt);
+      if (firstQuestionAt === Infinity) firstQuestionAt = g.revealAt;
+      answerWindows.push(tile.time - g.revealAt);
+      itemVsWindow.push([g.q?.difficulty ?? 0, tile.time - g.revealAt]);
+      answerMissMs.push(strikeWindows(tile.strikeSec).miss * 1000);
+      difficultyAtGate.push(game.difficulty);
+    }
+
+    // sample the chart shape once per bar for a variety signature
+    for (const bg of game.barGrid) {
+      if (bg.t > now - 0.02 && bg.t <= now && sigBars < 4000) {
+        sigBars++;
+        chartSignature.push(`${bg.cells}/${bg.playEvery}`);
+      }
+    }
+
+    const due = now - 0.012;
+    for (const note of game.notes) {
+      if (!note.active || note.state !== 0) continue;
+      if (Math.abs(note.time - due) > 0.015) continue;
+      if (note.isChoice) {
+        if (answer === "never" || skill === "none") continue;
+        if (note.correct !== (answer === "right")) continue;
+        game.hit(note.lane, note.time + 0.012);
+        continue;
+      }
+      if (rnd() >= cfg.p) continue;
+      const jitter = ((rnd() * 2 - 1) * cfg.jitterMs) / 1000;
+      game.hit(note.lane, note.time + jitter + 0.012);
+    }
+
+    game.update(0.02);
+  }
+
+  const gaps: number[] = [];
+  for (let i = 1; i < questionAt.length; i++) gaps.push(questionAt[i]! - questionAt[i - 1]!);
+
+  const out: Probe = {
+    skill,
+    breakdownAt,
+    breakdowns,
+    firstQuestionAt,
+    questionGaps: gaps,
+    answerWindows,
+    answerMissMs,
+    difficultyAtGate,
+    itemVsWindow,
+    finalDifficulty: game.difficulty,
+    notesMissed: game.notesMissed,
+    notesHit: game.notesHit,
+    chartSignature,
+  };
+  game.destroy();
+  return out;
+}
+
+const fmt = (v: number) => (Number.isFinite(v) ? v.toFixed(2) : "never");
+
+if (import.meta.filename === process.argv[1]) {
+  for (const skill of ["none", "moderate", "expert"] as Skill[]) {
+    const r = await probe(skill, 240, "right");
+    console.log(
+      `${skill.padEnd(9)} breakdown@${fmt(r.breakdownAt).padStart(7)}s  breakdowns=${String(r.breakdowns).padStart(3)}  ` +
+        `q1@${fmt(r.firstQuestionAt).padStart(6)}s  gap~${fmt(r.questionGaps.length ? r.questionGaps.reduce((a, b) => a + b, 0) / r.questionGaps.length : NaN)}s  ` +
+        `lv=${r.finalDifficulty.toFixed(2)}  hit=${r.notesHit} miss=${r.notesMissed}`,
+    );
+    console.log(
+      `          answer window s: ${r.answerWindows.slice(0, 10).map((x) => x.toFixed(2)).join(" ")}`,
+    );
+    console.log(
+      `          answer miss  ms: ${r.answerMissMs.slice(0, 10).map((x) => x.toFixed(1)).join(" ")}`,
+    );
+    console.log(
+      `          lv at gate     : ${r.difficultyAtGate.slice(0, 10).map((x) => x.toFixed(2)).join(" ")}`,
+    );
+    const uniq = new Set(r.chartSignature);
+    console.log(`          bars=${r.chartSignature.length} distinct cell shapes=${uniq.size} ${[...uniq].join(",")}`);
+  }
+
+  // windows across the difficulty range for an ordinary dense note
+  console.log("\nanswer window by ITEM difficulty (pure; must never decrease):");
+  for (const d of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1]) {
+    const plan = answerPlan({ difficulty: d });
+    console.log(
+      `  item ${d.toFixed(2)}: read ${plan.readSec.toFixed(2)}s  strike +/-${(plan.strikeSec * 1000).toFixed(0)}ms`,
+    );
+  }
+}

--- a/dynawalla/games/rhythm/src/game/answer.test.ts
+++ b/dynawalla/games/rhythm/src/game/answer.test.ts
@@ -1,0 +1,101 @@
+/**
+ * THE ANSWERING WINDOW IS A PURE FUNCTION OF THE ITEM, AND IT NEVER SHRINKS.
+ *
+ * The pacing audit's finding, in seventeen games: a comprehension window derived
+ * from a motion constant that is also the escalation knob. This file asserts the
+ * negation of that, three ways — on the plan, on the judged window a tile is
+ * actually given, and on what a four-minute run delivers at every tempo.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { answerPlan, READ_CEIL, READ_FLOOR, STRIKE_CEIL, STRIKE_FLOOR } from "./answer.ts";
+import { strikeWindows } from "./judge.ts";
+
+/** Fine enough that a non-monotone step anywhere in [0,1] is caught. */
+const SWEEP = 2001;
+
+test("the plan is monotone non-decreasing in item difficulty, everywhere", () => {
+  let prevRead = -Infinity;
+  let prevStrike = -Infinity;
+  for (let i = 0; i < SWEEP; i++) {
+    const d = i / (SWEEP - 1);
+    const p = answerPlan({ difficulty: d });
+    assert.ok(
+      p.readSec >= prevRead,
+      `reading time fell from ${prevRead.toFixed(4)}s to ${p.readSec.toFixed(4)}s at item ` +
+        `difficulty ${d.toFixed(4)}; a harder question must never get less time`,
+    );
+    assert.ok(
+      p.strikeSec >= prevStrike,
+      `the strike window fell from ${(prevStrike * 1000).toFixed(1)}ms to ` +
+        `${(p.strikeSec * 1000).toFixed(1)}ms at item difficulty ${d.toFixed(4)}`,
+    );
+    prevRead = p.readSec;
+    prevStrike = p.strikeSec;
+  }
+});
+
+test("a harder item gets STRICTLY more, not merely not-less", () => {
+  // "Never less" is satisfied by a constant, and a constant is what the audit
+  // found in game after game. The difference has to be felt.
+  const easy = answerPlan({ difficulty: 0.1 });
+  const hard = answerPlan({ difficulty: 0.9 });
+  assert.ok(
+    hard.readSec - easy.readSec > 2,
+    `a hard item got only ${(hard.readSec - easy.readSec).toFixed(2)}s more reading than an easy one`,
+  );
+  assert.ok(
+    hard.strikeSec - easy.strikeSec > 0.15,
+    `a hard item got only ${((hard.strikeSec - easy.strikeSec) * 1000).toFixed(0)}ms more to strike in`,
+  );
+});
+
+test("the plan depends on the item and on NOTHING else", () => {
+  // Everything that used to reach into this window — bpm, the difficulty
+  // scalar, the bar count, the run's state — is not an argument, so the only
+  // way to prove purity is that the same item always answers the same.
+  const item = { difficulty: 0.37 };
+  const first = answerPlan(item);
+  for (let i = 0; i < 100; i++) {
+    const again = answerPlan({ difficulty: 0.37 });
+    assert.deepEqual(again, first, "the same item answered differently on call " + i);
+  }
+  // Extra fields on the item are ignored: a host that decorates its questions
+  // cannot move a child's reading time by doing so.
+  const decorated = answerPlan({ difficulty: 0.37, prompt: "9 x 7", id: "z" } as { difficulty: number });
+  assert.deepEqual(decorated, first);
+});
+
+test("a host that violates the [0,1] contract cannot take time AWAY", () => {
+  for (const d of [-5, -0.0001, NaN, Infinity, -Infinity, 2, 1e9]) {
+    const p = answerPlan({ difficulty: d });
+    assert.ok(
+      p.readSec >= READ_FLOOR && p.readSec <= READ_CEIL,
+      `difficulty ${d} produced a reading window of ${p.readSec}s`,
+    );
+    assert.ok(p.strikeSec >= STRIKE_FLOOR && p.strikeSec <= STRIKE_CEIL);
+  }
+  // Unknown difficulty is not evidence of mastery, so it gets the EASIEST plan.
+  assert.equal(answerPlan({ difficulty: NaN }).readSec, READ_FLOOR);
+});
+
+test("a tile's judged window is the plan's, and is never clamped back onto the motion constant", () => {
+  // `windowsFor` clamps against BASE_WINDOWS.miss = 205ms. Every plan is wider
+  // than that, so reusing it would have silently flattened the whole range.
+  let prev = -Infinity;
+  for (let i = 0; i < SWEEP; i++) {
+    const d = i / (SWEEP - 1);
+    const plan = answerPlan({ difficulty: d });
+    const w = strikeWindows(plan.strikeSec);
+    assert.equal(w.miss, plan.strikeSec, `the tile at item ${d} was not judged on its own plan`);
+    assert.ok(w.miss >= prev, "the judged window shrank as the item got harder");
+    assert.ok(w.perfect <= w.great && w.great <= w.good && w.good <= w.miss, "windows out of order");
+    prev = w.miss;
+  }
+  assert.ok(
+    strikeWindows(answerPlan({ difficulty: 0 }).strikeSec).miss > 0.205,
+    "the easiest item's window is no wider than the note-timing constant it was supposed to escape",
+  );
+});

--- a/dynawalla/games/rhythm/src/game/answer.ts
+++ b/dynawalla/games/rhythm/src/game/answer.ts
@@ -1,0 +1,105 @@
+/**
+ * HOW LONG YOU GET TO ANSWER.
+ *
+ * Two numbers, and both of them are a pure function of the QUESTION and of
+ * nothing else — not the tempo, not the difficulty scalar, not how well the run
+ * is going, not what bar it is.
+ *
+ * ## Why this file exists at all
+ *
+ * `dynawalla/docs/PACING_AUDIT_2026-07.md` found the same defect in seventeen
+ * games: a comprehension window derived from a motion constant that is ALSO the
+ * escalation knob. Splitbeat had it twice.
+ *
+ *   - The reading lead was `revealT0 + spb * 4 * (1 + inhaleBars)`, and `spb`
+ *     is `60 / bpm`, and `bpm` climbs with the difficulty. `READ_SEC` was added
+ *     as a FLOOR under that, which stopped it collapsing but did not make it
+ *     monotone: a live run measured 7.35 s, 7.20, 7.05, 6.92, 6.54, 6.42, 6.30,
+ *     6.19 — eight consecutive questions, each one HARDER than the last and
+ *     each one given LESS time than the last, all of them technically above the
+ *     6 s floor. The floor was doing its job and the shape was still wrong.
+ *
+ *   - The strike window on the three answer tiles came out of `windowsFor`,
+ *     which is a function of note SPACING. It happened to sit at the flat
+ *     ±205 ms ceiling for every tempo this game reaches, so it was not
+ *     misbehaving yet — but it was one bpm constant away from doing so, and
+ *     "not currently broken" is not a property you can assert.
+ *
+ * ## The shape
+ *
+ * Affine and increasing in `Question.difficulty`, which the contract defines on
+ * [0,1]. Increasing is stronger than the requirement — a harder question must
+ * never get LESS time — and it is stronger on purpose, because "never less" is
+ * satisfied by a constant and a constant is what the pacing audit found
+ * everywhere. A child asked to regroup two digits gets meaningfully longer than
+ * a child asked a single-digit fact, and nothing about the run can take it back.
+ *
+ * `READ_FLOOR` is 6 s because `dw.ns.compare.whole-numbers` publishes a p50
+ * fluency target of 9 s and the gate's clock is measured from the instant the
+ * tiles become strikeable rather than from the reveal, so the reveal-to-strike
+ * lead is reading time on top of thinking time. `READ_CEIL` is 9.5 s: at the top
+ * of the ladder that is a bar and a half of extra music at every tempo the game
+ * plays.
+ *
+ * ## Delivered exactly, not approximately
+ *
+ * A gate's tiles land on a bar line, because this is a rhythm game and a drummer
+ * can feel a downbeat coming. The naive way to spend a reading budget on a
+ * bar-quantised game is to round the budget UP to a whole number of bars, and
+ * that reintroduces the tempo: the delivered window becomes
+ * `barDur * ceil(plan / barDur)`, which is not monotone in the item because
+ * `barDur` moves underneath it.
+ *
+ * So the quantisation is spent on the OTHER end. The gate bar stays on the grid
+ * and the REVEAL is scheduled `readSec` before it — mid-bar if that is where it
+ * falls, which is fine because a reveal is a gain ramp and a box of text, not a
+ * note. `core.ts` sizes the inhale generously enough that the reveal always
+ * lands at or after the reveal bar's own start, and then sets
+ * `revealAt = gateTime - plan.readSec` exactly. Delivered IS planned, at every
+ * tempo, for every item.
+ */
+
+/** Seconds of reading for the easiest possible item. */
+export const READ_FLOOR = 6;
+/** Seconds of reading for the hardest possible item. */
+export const READ_CEIL = 9.5;
+
+/**
+ * Half-width of the strike window on an answer tile, in seconds, for the
+ * easiest item.
+ *
+ * Wider than `BASE_WINDOWS.miss` (±205 ms) because a tile is not a groove note:
+ * missing it costs an ANSWER, and the child's hand is arriving from a decision
+ * rather than from a pulse they were already riding.
+ */
+export const STRIKE_FLOOR = 0.3;
+/** …and for the hardest item. */
+export const STRIKE_CEIL = 0.55;
+
+export type AnswerPlan = {
+  /** Seconds between the question appearing and its tiles becoming strikeable. */
+  readonly readSec: number;
+  /** Half-width of the window around the strike instant, in seconds. */
+  readonly strikeSec: number;
+};
+
+/**
+ * The contract puts `Question.difficulty` on [0,1]. A host that ignores that is
+ * not a reason to hand a child a negative reading window, so it is clamped, and
+ * a host that hands over `NaN` gets the EASIEST plan rather than the hardest —
+ * unknown difficulty is not evidence of mastery.
+ */
+function itemDifficulty(item: { difficulty: number }): number {
+  const d = item.difficulty;
+  if (!Number.isFinite(d)) return 0;
+  return d < 0 ? 0 : d > 1 ? 1 : d;
+}
+
+/** The answering plan for one item. Pure; depends on nothing but the item. */
+export function answerPlan(item: { difficulty: number }): AnswerPlan {
+  const d = itemDifficulty(item);
+  return {
+    readSec: READ_FLOOR + (READ_CEIL - READ_FLOOR) * d,
+    strikeSec: STRIKE_FLOOR + (STRIKE_CEIL - STRIKE_FLOOR) * d,
+  };
+}

--- a/dynawalla/games/rhythm/src/game/chart.test.ts
+++ b/dynawalla/games/rhythm/src/game/chart.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { grooveBar, polyBar, subdivisionFor, MUSICAL_CELLS, type ChartNote } from "./chart.ts";
+import { showcaseBar, polyBar, subdivisionFor, MUSICAL_CELLS, type ChartNote } from "./chart.ts";
+import { grooveBar, laneOf, newGroove } from "./groove.ts";
 import { windowsFor, verdictFor, BASE_WINDOWS } from "./judge.ts";
 import { createStubHost, parseRat, fmt, rat } from "../stubHost.ts";
 
@@ -31,8 +32,10 @@ test("an answer that is not a rhythm returns null rather than being forced", () 
 
 test("every generated note lands exactly on a cell boundary", () => {
   for (const cells of MUSICAL_CELLS) {
+    const g = newGroove(cells * 31 + 7);
+    g.cells = cells;
     for (let bar = 0; bar < 40; bar++) {
-      grooveBar({ bar, cells, accentEvery: 2, density: 0.7, difficulty: 4, showcase: false }, out);
+      grooveBar(g, 0.55, out);
       for (const n of out) {
         const expected = (n.cell * 4) / n.cells;
         assert.ok(
@@ -47,8 +50,10 @@ test("every generated note lands exactly on a cell boundary", () => {
 
 test("a bar always announces itself on beat one", () => {
   for (const cells of MUSICAL_CELLS) {
+    const g = newGroove(cells * 17 + 3);
+    g.cells = cells;
     for (let bar = 0; bar < 30; bar++) {
-      grooveBar({ bar, cells, accentEvery: 2, density: 0.2, difficulty: 1, showcase: false }, out);
+      grooveBar(g, 0, out);
       assert.ok(out.some((n) => n.beat === 0), `bar ${bar} cells ${cells} lost its downbeat`);
     }
   }
@@ -56,8 +61,11 @@ test("a bar always announces itself on beat one", () => {
 
 test("notes never collide within a lane", () => {
   for (const cells of MUSICAL_CELLS) {
+    const g = newGroove(cells * 101 + 11);
+    g.cells = cells;
+    g.accentEvery = 3;
     for (let bar = 0; bar < 60; bar++) {
-      grooveBar({ bar, cells, accentEvery: 3, density: 1, difficulty: 8, showcase: false }, out);
+      grooveBar(g, 1, out);
       const seen = new Set<string>();
       for (const n of out) {
         const k = `${n.lane}@${n.beat.toFixed(6)}`;
@@ -70,8 +78,11 @@ test("notes never collide within a lane", () => {
 
 test("the showcase plays the answer in full — every slice is struck", () => {
   for (const cells of MUSICAL_CELLS) {
-    grooveBar({ bar: 3, cells, accentEvery: 2, density: 1, difficulty: 3, showcase: true }, out);
+    showcaseBar(cells, 2, out);
     assert.equal(out.length, cells, `showcase at ${cells} cells produced ${out.length} notes`);
+    for (const n of out) {
+      assert.equal(n.lane, laneOf(n.cell, cells), "the payoff must lane a slice the way the groove does");
+    }
   }
 });
 

--- a/dynawalla/games/rhythm/src/game/chart.ts
+++ b/dynawalla/games/rhythm/src/game/chart.ts
@@ -1,14 +1,18 @@
 /**
- * Pattern generation.
+ * Pattern generation: the fixed shapes.
  *
  * A bar is a grid of `cells` equal slices — which is exactly what a denominator
  * is. `cells: 8` means the bar is cut into eighths, the floor is ruled into 8
  * segments, and the notes land on the cuts. When the player answers a gate with
  * `1/8`, the world re-rules itself into 8 and they PLAY the answer they gave.
  *
- * Lane assignment follows metric weight rather than chance, because a random
- * sprinkle of notes does not feel like a groove and a child can tell.
+ * The ORDINARY bar — the one the player spends almost every second inside —
+ * lives in `groove.ts`, because it is no longer a pure function of the bar
+ * index: it evolves. What is left here is the three shapes that are fixed by
+ * what they mean, plus the mapping from an answer to a subdivision.
  */
+
+import { laneOf } from "./groove.ts";
 
 export type Lane = 0 | 1 | 2;
 
@@ -66,77 +70,22 @@ function rngFor(seed: number) {
   };
 }
 
-/** Lane by metric weight: downbeats are low, backbeats are mid, the rest ride. */
-function laneFor(cell: number, cells: number): Lane {
-  const beat = (cell * 4) / cells;
-  const onBeat = Math.abs(beat - Math.round(beat)) < 1e-9;
-  if (cells === 2 || cells % 4 === 0) {
-    if (onBeat) {
-      const b = Math.round(beat) % 4;
-      return b === 0 || b === 2 ? 0 : 1;
-    }
-    return 2;
-  }
-  // 3, 6, 12: a cyclic three-feel. Every third cell is the anchor.
-  const m = cell % 3;
-  return m === 0 ? 0 : m === 1 ? 2 : 1;
-}
-
-export type BarSpec = {
-  bar: number;
-  cells: number;
-  accentEvery: number;
-  /** 0..1, how much of the grid is filled beyond the structural notes */
-  density: number;
-  difficulty: number;
-  /** true for the payoff bars right after a correct gate */
-  showcase: boolean;
-};
-
 /**
- * One bar of groove. Structural notes (bar start, backbeats) are always
- * present; everything else is filled by density so the pattern breathes.
+ * The payoff bar: the answer, played in full.
+ *
+ * Every slice is struck, because the point of the bar is that the denominator
+ * the child just answered with is the thing under their hands. Lane assignment
+ * comes from `groove.ts` so the payoff and the groove agree about which lane a
+ * slice belongs to — they disagreed once, and a payoff that moves the kick to a
+ * lane the player has not been using is a payoff they fumble.
  */
-export function grooveBar(spec: BarSpec, out: ChartNote[]): ChartNote[] {
+export function showcaseBar(cells: number, accentEvery: number, out: ChartNote[]): ChartNote[] {
   out.length = 0;
-  const { bar, cells, accentEvery, density, difficulty, showcase } = spec;
-  const rnd = rngFor(bar * 2654435761 + cells * 40503);
-
-  for (let i = 0; i < cells; i++) {
-    const beat = (i * 4) / cells;
-    const lane = laneFor(i, cells);
-    const accent = i % accentEvery === 0;
-
-    let keep: boolean;
-    if (i === 0) {
-      keep = true; // the bar always announces itself
-    } else if (showcase) {
-      keep = true; // the payoff plays the answer in full, every slice
-    } else if (lane === 1) {
-      keep = true; // never drop a backbeat; it is the spine of the groove
-    } else if (lane === 0) {
-      keep = rnd() < 0.72 + density * 0.28;
-    } else {
-      keep = rnd() < density;
-    }
-    if (keep) out.push({ beat, lane, accent, cell: i, cells });
+  const n = Math.max(2, Math.round(cells));
+  const every = Math.max(1, Math.min(Math.round(accentEvery), n));
+  for (let i = 0; i < n; i++) {
+    out.push({ beat: (i * 4) / n, lane: laneOf(i, n), accent: i % every === 0, cell: i, cells: n });
   }
-
-  // Syncopation: from difficulty 5, occasionally pull a note off the grid into
-  // the slot just before a backbeat. This is what stops long runs feeling like
-  // a metronome.
-  if (!showcase && difficulty >= 5 && cells >= 8 && rnd() < 0.35) {
-    const target = Math.round((cells * 3) / 4); // beat 3
-    const idx = out.findIndex((n) => n.cell === target);
-    if (idx >= 0 && target - 1 > 0 && !out.some((n) => n.cell === target - 1)) {
-      const n = out[idx]!;
-      n.cell = target - 1;
-      n.beat = ((target - 1) * 4) / cells;
-      n.accent = true;
-    }
-  }
-
-  out.sort((a, b) => a.beat - b.beat);
   return out;
 }
 
@@ -174,10 +123,22 @@ export function polyBar(bar: number, out: ChartNote[]): ChartNote[] {
   return out;
 }
 
-/** A near-empty bar: the inhale before a gate, so the question can be read. */
-export function inhaleBar(out: ChartNote[]): ChartNote[] {
+/**
+ * A near-empty bar: the inhale before a gate, so the question can be read.
+ *
+ * Two notes, always — the density is the point and `phase` may not touch it.
+ * What `phase` moves is WHERE the second one falls, and that matters for a
+ * reason beyond taste: the inhale used to be byte-identical every single time,
+ * and a cycle carries three or four of them, so a long run was full of
+ * verbatim-repeating phrases even when the groove itself was evolving. Both
+ * notes also used to land in lane 0, which meant the sparsest bar in the game
+ * — the one a beginner has the most time to look at — taught them nothing
+ * about the other two lanes.
+ */
+export function inhaleBar(phase: number, out: ChartNote[]): ChartNote[] {
   out.length = 0;
   out.push({ beat: 0, lane: 0, accent: true, cell: 0, cells: 4 });
-  out.push({ beat: 2, lane: 0, accent: false, cell: 2, cells: 4 });
+  const second = [2, 3, 2, 1][((phase % 4) + 4) % 4]!;
+  out.push({ beat: second, lane: laneOf(second, 4), accent: false, cell: second, cells: 4 });
   return out;
 }

--- a/dynawalla/games/rhythm/src/game/core.test.ts
+++ b/dynawalla/games/rhythm/src/game/core.test.ts
@@ -19,7 +19,8 @@ import { installFakeAudio } from "../dev/fakeAudio.ts";
 const audio = installFakeAudio();
 
 // After the fake is installed, so `new AudioEngine()` finds it.
-const { Game, MAX_CHARGE, READ_SEC } = await import("./core.ts");
+const { Game, MAX_CHARGE } = await import("./core.ts");
+const { READ_FLOOR } = await import("./answer.ts");
 
 import type { Host } from "../contract.ts";
 
@@ -166,10 +167,15 @@ test("a gate that expires does not move the difficulty and does not cost charge"
   const r = await play("never", LONG_RUN_SEC, 5);
 
   assert.ok(r.difficultyAsked.length > 4);
-  assert.equal(
-    r.difficulty,
-    5,
-    "a child who was still computing has said nothing about the maths; the ladder must not move",
+  // Exact to floating point, not merely "close": the bot played every ordinary
+  // note perfectly for four minutes, so the NOTE channel of the flow controller
+  // is pinned at 1 and is straining upward the whole time. The ladder holds
+  // because the controller steers on the WORSE of its two channels and the
+  // maths channel heard nothing at all — which is the claim.
+  assert.ok(
+    Math.abs(r.difficulty - 5) < 1e-9,
+    `a child who was still computing has said nothing about the maths; the ladder must not ` +
+      `move, and it moved to ${r.difficulty}`,
   );
   assert.equal(r.charge, MAX_CHARGE, "the run was played perfectly; only the gates went unanswered");
   assert.equal(r.phase, "playing", "an unanswered gate must not be able to end a run on its own");
@@ -226,9 +232,9 @@ test("the reading window never shrinks because the tempo went up", async () => {
 
   const worst = Math.min(...r.readingWindows);
   assert.ok(
-    worst >= READ_SEC,
+    worst >= READ_FLOOR,
     `a child got ${worst.toFixed(2)}s to read a question at ${r.bpm} BPM; the floor is ` +
-      `${READ_SEC}s and it must not fall as the music speeds up`,
+      `${READ_FLOOR}s and it must not fall as the music speeds up`,
   );
 });
 
@@ -284,7 +290,7 @@ test("the reading window survives a pause taken after a sector change", async ()
     );
     const barDur = (60 / game.bpm) * 4;
     assert.ok(
-      barDur * (1 + inner.cycleInhale) >= READ_SEC,
+      barDur * (1 + inner.cycleInhale) >= READ_FLOOR,
       `a resumed cycle at ${game.bpm} BPM leads by ${(barDur * (1 + inner.cycleInhale)).toFixed(2)}s`,
     );
   }

--- a/dynawalla/games/rhythm/src/game/core.ts
+++ b/dynawalla/games/rhythm/src/game/core.ts
@@ -17,20 +17,29 @@
  * delivered instead by zoom, shake, lane flash and particles — and true hitstop
  * is allowed only when no note is within 0.35s, which is exactly the aftermath
  * bar where the gate shatters.
+ *
+ * THE RUN NEVER RESTARTS. See `oweHeart`.
  */
 
+import {
+  demandFor,
+  observe,
+  quickness,
+  revealPlan,
+  SECOND_GRADE_FLOW,
+  seedSuccess,
+  settle,
+  type FlowSpec,
+  type RevealPlan,
+} from "../../../../packs/shared/game-pacing/index.ts";
 import { AudioEngine } from "../audio/engine.ts";
 import { SECTORS, scheduleBar, cadence, type Sector } from "../audio/music.ts";
 import type { Host, Question } from "../contract.ts";
-import {
-  grooveBar,
-  polyBar,
-  inhaleBar,
-  subdivisionFor,
-  type ChartNote,
-  type Lane,
-} from "./chart.ts";
-import { layerFor, multiplierFor, verdictFor, windowsFor, VERDICT_SCORE, type Verdict } from "./judge.ts";
+import { answerPlan, type AnswerPlan } from "./answer.ts";
+import { polyBar, inhaleBar, showcaseBar, subdivisionFor, type ChartNote, type Lane } from "./chart.ts";
+import { evolve, grooveBar, newGroove, ruleInto, type Groove } from "./groove.ts";
+import { layerFor, multiplierFor, strikeWindows, verdictFor, windowsFor, VERDICT_SCORE, type Verdict } from "./judge.ts";
+import { loadFlow, saveFlow } from "./memory.ts";
 
 export type { Lane };
 
@@ -43,23 +52,59 @@ const LEAD_IN = 0.45;
 export const MAX_CHARGE = 5;
 
 /**
- * The floor on how long a question is on screen before its answer has to be
- * struck, in seconds.
+ * SPLITBEAT's flow shape.
  *
- * The lead used to be a flat two bars — `revealT0 + spb * 8` — and `spb` comes
- * straight off `bpm`, which `applyDifficulty` raises with the difficulty. So
- * the reading window was `f(difficulty)` and it pointed the wrong way: getting
- * good sped the music up, and faster music gave a child LESS time to work out a
- * HARDER sum. At difficulty 1 that was 4.9 s; by difficulty 10 it was 3.2 s.
+ * `SECOND_GRADE_FLOW` with two changes, both of which this game earns:
  *
- * `dynawalla/docs/EXPERIENCE_DESIGN.md`: "COMPREHENSION — not budgeted. The
- * child's time. Measured, never limited." A gate cannot be literally unlimited
- * — it is a bar of music — but the lead is now measured in seconds and the
- * inhale is stretched by however many bars it takes to cover them. Six seconds
- * is the p50 cadence target for two-digit-with-regrouping and the p90 for a
- * single-digit fact; at slow tempos a child gets more, never less.
+ *  - `start` is not `0.04`. A run resumes wherever the last one left off (see
+ *    `memory.ts`), and a FIRST run starts at `0.06` — barely above the floor,
+ *    because the founder is a drummer and a mathematician and could not last a
+ *    few seconds, so the opening has to be genuinely trivial.
+ *  - `fallSeconds` is 26 rather than 50. Relief is not earned, and in a game
+ *    where the evidence arrives sixty times a second rather than once per
+ *    answer it should arrive quickly too.
  */
-export const READ_SEC = 6;
+export const SPLITBEAT_FLOW: FlowSpec = {
+  ...SECOND_GRADE_FLOW,
+  start: 0.06,
+  fallSeconds: 26,
+};
+
+/**
+ * THE HEART.
+ *
+ * `charge` used to be five integer blocks and every unhit note took one. Notes
+ * land about every 0.6 s at the opening, so a player who was merely WATCHING —
+ * a child who has just been handed the device, or an adult reading the
+ * instructions — was dead in **3.14 seconds, measured**, and the first question
+ * did not appear until 12.69 s. It was not possible to lose the run by playing
+ * badly, because it was not possible to reach anything to play badly at.
+ *
+ * The heart is now continuous on [0,1] and it REFILLS as you play. The three
+ * constants are chosen against the note rate the opening actually produces
+ * (three notes a bar at 92 BPM is 1.15 notes/s):
+ *
+ *  - a player who taps NOTHING drains at `1.15 * MISS_COST` = 0.0288/s, so an
+ *    untouched heart empties in about 35 s — and the first question now arrives
+ *    inside 9 s, so they meet a question before they ever meet the consequence;
+ *  - a player landing HALF their notes is at `0.575*0.020 - 0.575*0.025`, a
+ *    drift of −0.0029/s: nearly two hundred seconds, and every gate they answer
+ *    puts it back. Half is survivable indefinitely in practice;
+ *  - a player landing 70% is net POSITIVE and stays full.
+ */
+const HEART_MISS = 0.025;
+const HEART_HIT = 0.02;
+const HEART_GATE_RIGHT = 0.34;
+const HEART_GATE_WRONG = -0.12;
+
+/**
+ * The moving estimate of how many notes are being landed, as an EMA weight.
+ *
+ * A twenty-four-note window: long enough that one fumbled sixteenth does not
+ * calm the world, short enough that a player who has genuinely lost the thread
+ * feels the world back off within a bar or two.
+ */
+const NOTE_WINDOW = 24;
 
 export type Note = {
   active: boolean;
@@ -74,6 +119,12 @@ export type Note = {
   gateId: number;
   label: string;
   correct: boolean;
+  /**
+   * For a choice tile, the half-width of its strike window in seconds, straight
+   * off `answerPlan(item)`. Zero for an ordinary note, which is judged on
+   * `spacing` instead. See `judge.ts`.
+   */
+  strikeSec: number;
   /** 0 pending, 1 struck, 2 missed */
   state: 0 | 1 | 2;
   verdict: Verdict | null;
@@ -81,6 +132,11 @@ export type Note = {
   bornAt: number;
   hitAt: number;
 };
+
+/** The windows a note is judged against — the ONE place the choice is made. */
+export function windowsForNote(n: Note): ReturnType<typeof windowsFor> {
+  return n.isChoice ? strikeWindows(n.strikeSec) : windowsFor(n.spacing);
+}
 
 export type Gate = {
   id: number;
@@ -95,9 +151,34 @@ export type Gate = {
   correctLane: Lane;
   cells: number | null;
   accentEvery: number;
+  /** the answering budget for this gate's item — pure, and fixed at spawn */
+  plan: AnswerPlan;
+  /**
+   * True when this gate is the one the player owes because the heart ran out.
+   * It is an ORDINARY gate in every other respect; the flag only decides
+   * whether the renderer says RESTART THE HEART over it.
+   */
+  debt: boolean;
   /** 0..1 animation drivers, advanced by the renderer's clock */
   shatter: number;
   crack: number;
+};
+
+/**
+ * A completed sum, held in front of the child.
+ *
+ * `packs/shared/game-pacing`'s rule, quoted from its own source: "**A shown
+ * reveal never expires.** … 'then go on' is the child's own hand, and a hand
+ * needs no deadline." So there is deliberately no deadline field here. The only
+ * things that take it down are the child's next struck note (after `settleMs`,
+ * so a tap already in flight cannot eat it) and the next question arriving,
+ * which is also something the child caused.
+ */
+export type Reveal = {
+  prompt: string;
+  answer: string;
+  bornAt: number;
+  plan: RevealPlan;
 };
 
 export type EventKind =
@@ -107,7 +188,9 @@ export type EventKind =
   | "gate-correct"
   | "gate-wrong"
   | "sector"
-  | "breakdown"
+  /** the heart hit zero and a question is now owed — the music does NOT stop */
+  | "heart-out"
+  /** the owed question was answered right and the heart is full again */
   | "revive"
   | "charge-up";
 
@@ -119,7 +202,16 @@ export type GameEvent = {
   strength: number;
 };
 
-export type Phase = "title" | "playing" | "breakdown" | "paused";
+/**
+ * There is no `"breakdown"`.
+ *
+ * The founder: *"I don't like that it 'restarts' … it shouldn't take you back to
+ * the beginning … when you have to do a math problem to go on it should flow
+ * with the regular game and not be a reset."* A phase the game could enter and
+ * have to be let out of IS the reset, however short it is, so the phase is gone
+ * rather than shortened. See `oweHeart`.
+ */
+export type Phase = "title" | "playing" | "paused";
 
 export type Fx = {
   shake: number;
@@ -162,8 +254,36 @@ export class Game {
   score = 0;
   combo = 0;
   bestCombo = 0;
-  charge = MAX_CHARGE;
-  difficulty = 1;
+
+  /**
+   * The one adaptive scalar, [0,1] — `packs/shared/game-pacing`'s.
+   *
+   * It drives the maths difficulty asked of the host, the tempo, the
+   * subdivision and the note count TOGETHER, in BOTH directions. That coupling
+   * is the whole answer to *"it should just go on and adjust and vary itself as
+   * you go on. If you keep sucking and losing then it should just get
+   * easier/stay easy."*
+   */
+  intensity = SPLITBEAT_FLOW.start;
+  /** the flow controller's estimate of how the MATHS is going */
+  gateSuccess = seedSuccess(SPLITBEAT_FLOW);
+  /**
+   * …and of how the PLAYING is going. Kept separate and combined by taking the
+   * WORSE of the two, so a child who is answering every sum right but cannot
+   * land the notes is not dragged up the ladder by half of their evidence.
+   * This is the channel that was missing: `adjustDifficulty` used to move on a
+   * gate outcome and nothing else, so a player who never survived long enough
+   * to REACH a gate never received any relief at all.
+   */
+  noteSuccess = seedSuccess(SPLITBEAT_FLOW);
+
+  /** 0..1. See HEART_MISS. */
+  heart = 1;
+  /** True between the heart emptying and the owed question being answered. */
+  heartDebt = false;
+  /** How many times the heart has run out this run. Never a game over. */
+  heartOuts = 0;
+
   /** Gates the child actually answered. An unanswered one is not an attempt. */
   gatesTotal = 0;
   gatesCorrect = 0;
@@ -181,11 +301,11 @@ export class Game {
 
   /** the gate the player is currently being asked, or null */
   activeGate: Gate | null = null;
-  /** the revive question during a breakdown */
-  reviveGate: Gate | null = null;
+  /** the completed sum being held after a wrong or unanswered gate */
+  reveal: Reveal | null = null;
 
-  cells = 4;
-  accentEvery = 2;
+  /** The evolving groove. The reason a long run does not repeat. */
+  readonly groove: Groove = newGroove();
   bpm = 92;
 
   readonly fx: Fx = {
@@ -223,6 +343,8 @@ export class Game {
   private schedTimer = 0;
   private laneLock = [0, 0, 0];
   private scratch: ChartNote[] = [];
+  /** seconds since the flow state was last written to storage */
+  private flowDirty = 0;
   private started = false;
 
   constructor(host: Host) {
@@ -232,21 +354,57 @@ export class Game {
     for (let i = 0; i < NOTE_POOL; i++) {
       this.notes.push({
         active: false, time: 0, lane: 0, accent: false, cell: 0, cells: 4, spacing: 0.5,
-        isChoice: false, gateId: -1, label: "", correct: false, state: 0, verdict: null,
-        delta: 0, bornAt: 0, hitAt: 0,
+        isChoice: false, gateId: -1, label: "", correct: false, strikeSec: 0, state: 0,
+        verdict: null, delta: 0, bornAt: 0, hitAt: 0,
       });
     }
     for (let i = 0; i < 6; i++) {
       this.gates.push({
         id: -1, active: false, q: null, time: 0, revealAt: 0, resolved: false, correct: false,
         answered: "", labels: ["", "", ""], correctLane: 0, cells: null, accentEvery: 2,
-        shatter: 0, crack: 0,
+        plan: answerPlan({ difficulty: 0 }), debt: false, shatter: 0, crack: 0,
       });
+    }
+    // A run resumes where the last one left off. A child who keeps struggling
+    // must not be made to re-earn the relief they already earned yesterday.
+    const remembered = loadFlow();
+    if (remembered) {
+      this.intensity = clamp(remembered.intensity, SPLITBEAT_FLOW.floor, SPLITBEAT_FLOW.ceiling);
+      this.gateSuccess = clamp(remembered.gateSuccess, 0, 1);
+      this.noteSuccess = clamp(remembered.noteSuccess, 0, 1);
     }
     for (let i = 0; i < 64; i++) {
       this.events.push({ kind: "hit", lane: 0, verdict: null, accent: false, strength: 1 });
     }
     for (let i = 0; i < 24; i++) this.barGrid.push({ t: -99, dur: 2, cells: 4, playEvery: 1 });
+  }
+
+  /**
+   * The 1..10 scalar the HUD shows and the host is asked in. A view of
+   * `intensity`, not a second source of truth — they drifted apart once and the
+   * host was served questions from a ladder the world was not on.
+   */
+  get difficulty(): number {
+    return 1 + this.intensity * 9;
+  }
+  set difficulty(v: number) {
+    this.intensity = clamp((v - 1) / 9, 0, 1);
+    this.gateSuccess = seedSuccess(SPLITBEAT_FLOW, this.intensity);
+    this.noteSuccess = this.gateSuccess;
+    this.applyDifficulty();
+  }
+
+  /** The heart, on the five-block scale the HUD draws it in. */
+  get charge(): number {
+    return this.heart * MAX_CHARGE;
+  }
+
+  /** The subdivision the world is ruled into right now. */
+  get cells(): number {
+    return this.groove.cells;
+  }
+  get accentEvery(): number {
+    return this.groove.accentEvery;
   }
 
   get sector(): Sector {
@@ -299,7 +457,11 @@ export class Game {
     const t = this.eng.now + LEAD_IN;
     this.noteCursor = 0;
     this.audioCursor = 0;
-    this.cycleStartBar = 0;
+    // Seat the FIRST cycle already one bar in, so a new player meets a question
+    // inside about seven seconds instead of thirteen. Meeting the maths early
+    // matters more at the start of a run than a full opening vamp does, and it
+    // has to happen well before the heart could possibly be in trouble.
+    this.cycleStartBar = -1;
     this.barTime[0] = t;
     this.barSpb[0] = 60 / this.bpm;
     this.applyDifficulty();
@@ -354,27 +516,45 @@ export class Game {
   private applyDifficulty(): void {
     const d = this.difficulty;
     this.bpm = 92 + d * 6 + this.sector.bpmBias;
-    this.grooveBars = d < 3 ? 6 : d < 6 ? 5 : 4;
-    // Bars get shorter as the tempo climbs, so the inhale gets longer to hold
-    // the reading window at or above READ_SEC. The lead is [reveal][inhale × n],
-    // so n bars of inhale buy (1 + n) bars of reading. Sparseness and time, not
-    // less feedback: an inhale bar is the sparsest bar the game plays.
-    const barDur = (60 / this.bpm) * 4;
-    this.inhaleBars = Math.max(1, Math.ceil(READ_SEC / barDur) - 1);
+    // Four groove bars at the bottom, three higher up: a question every ~16 s
+    // rather than every ~29 s. The founder wanted the maths to FLOW with the
+    // game, and a gate you meet twice a minute is not part of the game.
+    this.grooveBars = this.intensity < 0.4 ? 4 : 3;
+    // A default only: `spawnGate` re-sizes this from the item it was actually
+    // handed, before any inhale bar is planned. Sizing is the only thing the
+    // tempo is allowed to touch; the WINDOW itself is `answer.ts`'s and the
+    // tempo cannot reach it.
+    this.inhaleBars = this.inhaleFor(answerPlan({ difficulty: 0 }).readSec);
     this.eng.setDelayTime((60 / this.bpm) * 0.75);
   }
 
-  private get maxCells(): number {
-    const d = this.difficulty;
-    return d < 3 ? 8 : d < 6 ? 12 : 16;
+  /**
+   * Inhale bars that put the reveal instant at or after the reveal bar's start.
+   *
+   * The lead is `[reveal][inhale x n][gate]`, so `n` bars of inhale buy
+   * `(1 + n)` bars of lead, and the reveal is placed `readSec` back from the
+   * gate. `n` therefore only has to satisfy `(1 + n) * barDur >= readSec`.
+   */
+  private inhaleFor(readSec: number): number {
+    const barDur = (60 / this.bpm) * 4;
+    return Math.max(1, Math.ceil(readSec / barDur) - 1);
   }
 
-  private get density(): number {
-    return clamp(0.2 + this.difficulty * 0.075, 0.2, 0.95);
+  /**
+   * The success estimate the controller steers on: the WORSE of the two
+   * channels.
+   *
+   * `demandFor` is monotone non-decreasing in success, so taking the minimum
+   * here is exactly `min(demandFor(gates), demandFor(notes))` — struggling in
+   * either channel calms the world, and climbing takes both. See `noteSuccess`.
+   */
+  get steer(): number {
+    return Math.min(this.gateSuccess, this.noteSuccess);
   }
 
-  private adjustDifficulty(delta: number): void {
-    this.difficulty = clamp(this.difficulty + delta, 1, 10);
+  /** Where the controller wants the world, right now. For tests and the HUD. */
+  get demand(): number {
+    return demandFor(SPLITBEAT_FLOW, this.steer);
   }
 
   /* ---------------------------------------------------------------- */
@@ -447,45 +627,38 @@ export class Game {
     }
 
     let list: ChartNote[];
-    let cells = clamp(this.cells, 2, this.maxCells);
+    let cells = this.groove.cells;
     let playEvery = 1;
-    let showcase = false;
 
     if (role === "inhale" || role === "gate" || role === "aftermath") {
-      list = inhaleBar(this.scratch);
+      list = inhaleBar(this.groove.phase + bar, this.scratch);
       cells = 4;
       if (role === "gate") list.length = 0;
       if (role === "aftermath") list.length = 0;
     } else if (role === "payoff") {
       const g = this.activeGate;
-      showcase = true;
       if (g && g.correct && g.cells) {
-        cells = g.cells;
-        this.accentEvery = g.accentEvery;
-        if (cells > this.maxCells) playEvery = Math.ceil(cells / this.maxCells);
-      } else {
-        cells = clamp(this.cells, 2, this.maxCells);
+        // The child answered with a denominator; the world re-rules itself into
+        // it and they PLAY the answer they gave.
+        ruleInto(this.groove, g.cells, g.accentEvery, this.intensity);
       }
-      list = grooveBar(
-        { bar, cells, accentEvery: this.accentEvery, density: 1, difficulty: this.difficulty, showcase: true },
-        this.scratch,
-      );
-      if (playEvery > 1) list = list.filter((n) => n.cell % playEvery === 0);
-    } else if (this.difficulty >= 6 && (bar * 7919) % 4 === 0) {
+      cells = this.groove.cells;
+      list = showcaseBar(cells, this.groove.accentEvery, this.scratch);
+      // A sixteenth-note showcase is a showcase, not an exam: at low intensity
+      // every other slice is DRAWN but not required.
+      const playable = Math.max(4, Math.round(4 + this.intensity * 12));
+      if (cells > playable) {
+        playEvery = Math.ceil(cells / playable);
+        list = list.filter((n) => n.cell % playEvery === 0);
+      }
+    } else if (this.intensity >= 0.6 && (bar * 7919) % 4 === 0) {
       list = polyBar(bar, this.scratch);
       cells = 12;
     } else {
-      list = grooveBar(
-        {
-          bar,
-          cells,
-          accentEvery: this.accentEvery,
-          density: this.density,
-          difficulty: this.difficulty,
-          showcase: false,
-        },
-        this.scratch,
-      );
+      // The ordinary bar, and the only one that evolves.
+      evolve(this.groove, this.intensity);
+      cells = this.groove.cells;
+      list = grooveBar(this.groove, this.intensity, this.scratch);
     }
 
     // Per-lane spacing drives the timing windows for every note in this bar.
@@ -511,6 +684,7 @@ export class Game {
       n.gateId = -1;
       n.label = "";
       n.correct = false;
+      n.strikeSec = 0;
       n.state = 0;
       n.verdict = null;
       n.bornAt = this.eng.now;
@@ -519,9 +693,6 @@ export class Game {
 
     if (role === "reveal") this.spawnGate(t0, spb);
     if (role === "gate") this.placeChoiceNotes(t0, spb);
-    if (showcase && this.activeGate?.correct && this.activeGate.cells) {
-      this.cells = clamp(this.activeGate.cells, 2, this.maxCells);
-    }
 
     const g = this.barGrid[this.gridCur % this.barGrid.length]!;
     this.gridCur++;
@@ -554,15 +725,35 @@ export class Game {
     g.id = ++this.gateSeq;
     g.active = true;
     g.q = q;
-    g.revealAt = revealT0;
-    // [reveal][inhale × cycleInhale][gate] — as many inhale bars as it takes for
-    // the lead to cover READ_SEC seconds. See READ_SEC.
+    g.plan = answerPlan(q);
+    // Size the inhale from THIS item, now — before a single inhale bar has been
+    // planned, and never again for this cycle. Sizing it in `applyDifficulty`
+    // instead meant every question, however easy, waited out the lead the
+    // HARDEST possible question would have needed, which put the first question
+    // of a run at 13.06 s.
+    this.cycleInhale = this.inhaleFor(g.plan.readSec);
+    // [reveal][inhale × cycleInhale][gate]. The GATE is on the grid, because a
+    // drummer can feel a downbeat coming and the three tiles land on one.
     g.time = revealT0 + spb * 4 * (1 + this.cycleInhale);
+    // …and the REVEAL is placed exactly `readSec` before it, wherever in the bar
+    // that falls. That is the whole trick: the quantisation is spent on the end
+    // that is a box of text rather than on the end that is a note, so the
+    // delivered reading window IS the planned one at every tempo. Rounding the
+    // BUDGET up to whole bars instead made the window a function of `bpm` —
+    // eight consecutive questions measured 7.35, 7.20, 7.05, 6.92, 6.54, 6.42,
+    // 6.30, 6.19 s, each harder than the last and each given less time. See
+    // `answer.ts`.
+    g.revealAt = g.time - g.plan.readSec;
     g.resolved = false;
     g.correct = false;
     g.answered = "";
+    g.debt = this.heartDebt;
     g.shatter = 0;
     g.crack = 0;
+    // The last question's evidence has been superseded by a new one. This is one
+    // of exactly two things that take a reveal down, and it is the child's own
+    // progress rather than a timer. See `Reveal`.
+    this.reveal = null;
 
     const sub = subdivisionFor(q.answer);
     g.cells = sub ? sub.cells : null;
@@ -587,8 +778,10 @@ export class Game {
   private placeChoiceNotes(t0: number, spb: number): void {
     const g = this.activeGate;
     if (!g) return;
-    // The bar we are actually planning is authoritative for the strike time.
+    // The bar we are actually planning is authoritative for the strike time, so
+    // the reveal instant moves with it and the delivered window stays exact.
     g.time = t0;
+    g.revealAt = t0 - g.plan.readSec;
     for (let lane = 0 as Lane; lane < 3; lane = (lane + 1) as Lane) {
       const n = this.takeNote();
       if (!n) break;
@@ -602,6 +795,9 @@ export class Game {
       n.gateId = g.id;
       n.label = g.labels[lane]!;
       n.correct = lane === g.correctLane;
+      // NOT `windowsFor(spacing)`. A tile's window is the item's, and a harder
+      // item's is wider — never narrower, and never touched by the tempo.
+      n.strikeSec = g.plan.strikeSec;
       n.state = 0;
       n.verdict = null;
       n.bornAt = this.eng.now;
@@ -633,13 +829,25 @@ export class Game {
       this.host.report({ questionId: g.q.id, correct, ms: Math.max(1, Math.round(ms)), answered });
     }
 
+    // The maths channel of the flow controller. `ms/1000` is THINKING time by
+    // the same argument the `report` above is: it starts when a tile could
+    // first be struck. See `game-pacing`'s latency contract.
+    this.gateSuccess = observe(SPLITBEAT_FLOW, this.gateSuccess, correct, ms / 1000);
+    // The GAME's debt, not the gate's flag. `g.debt` only decides whether the
+    // banner is drawn; a debt raised while this question was already in flight
+    // is still a debt, and this question is still the toll that clears it.
+    const wasDebt = this.heartDebt;
+    this.clearDebt();
+
     if (correct) {
       this.gatesCorrect++;
+      // Speed is REWARDED, never enforced: `quickness` can only ADD to the
+      // bonus, and a child who took a minute still gets the full base.
       const bonus = g.cells ? 400 + g.cells * 60 : 400;
-      this.score += bonus * multiplierFor(this.combo);
-      this.charge = Math.min(MAX_CHARGE, this.charge + 1);
-      this.adjustDifficulty(0.34);
-      this.emit("gate-correct", g.correctLane, null, true, 1);
+      const swift = 1 + quickness(SPLITBEAT_FLOW, ms / 1000);
+      this.score += Math.round(bonus * swift) * multiplierFor(this.combo);
+      this.heart = clamp(this.heart + (wasDebt ? 1 : HEART_GATE_RIGHT), 0, 1);
+      this.emit(wasDebt ? "revive" : "gate-correct", g.correctLane, null, true, 1);
       this.host.haptic("success");
       if (this.soundOn) {
         this.eng.shatter(t, 1, 12);
@@ -651,10 +859,13 @@ export class Game {
       this.requestHitstop(0.07);
       if (this.gatesCorrect % 4 === 0) this.advanceSector();
     } else {
-      this.charge -= 2;
       this.combo = 0;
       this.perfectRun = 0;
-      this.adjustDifficulty(-0.22);
+      // A wrong answer at a debt gate still buys the heart back. The question
+      // was the toll, and a child who paid it and got it wrong has just been
+      // shown the sum — which is the point — so they play on either way.
+      this.heart = clamp(this.heart + (wasDebt ? 0.6 : HEART_GATE_WRONG), 0, 1);
+      this.showReveal(g);
       this.emit("gate-wrong", g.correctLane, null, true, 1);
       this.host.haptic("failure");
       if (this.soundOn) {
@@ -670,8 +881,31 @@ export class Game {
         }
       }
       this.kick(1.0, 0.965, 0.85);
-      if (this.charge <= 0) this.enterBreakdown();
+      if (this.heart <= 0) this.oweHeart();
     }
+  }
+
+  /**
+   * Put the finished sum in front of the child and leave it there.
+   *
+   * Accent colour, never red — `dynawalla/docs/EXPERIENCE_DESIGN.md`, and the
+   * renderer draws it in `SectorTheme.horizon`. The hold comes from
+   * `revealPlan`, whose `holdMs` is `Infinity` whenever there is a reveal at
+   * all, so nothing in this file ever computes a deadline for it.
+   */
+  private showReveal(g: Gate): void {
+    if (!g.q) return;
+    const plan = revealPlan(SPLITBEAT_FLOW, this.intensity);
+    if (plan.holdMs <= 0) return; // mastery: skip the ceremony
+    this.reveal = { prompt: g.q.prompt, answer: g.q.answer, bornAt: this.eng.now, plan };
+  }
+
+  /** The child's own hand, once it has settled. See `Reveal`. */
+  private dismissReveal(): void {
+    const r = this.reveal;
+    if (!r) return;
+    if ((this.eng.now - r.bornAt) * 1000 < r.plan.settleMs) return;
+    this.reveal = null;
   }
 
   /**
@@ -702,6 +936,17 @@ export class Game {
     this.gatesExpired++;
     const t = this.eng.now;
     const spb = 60 / this.bpm;
+    // The sum is completed in front of them all the same. Being still mid-thought
+    // is the case where seeing it finished is worth the most.
+    this.showReveal(g);
+    // An unanswered gate cannot be the toll for the heart either — the child was
+    // not refusing, they were computing — so the debt is forgiven and the heart
+    // comes back. The alternative is a debt gate that expires into another debt
+    // gate, which is the restart loop wearing a different hat.
+    if (this.heartDebt) {
+      this.clearDebt();
+      this.heart = Math.max(this.heart, 0.6);
+    }
     this.emit("gate-wrong", g.correctLane, null, true, 0.55);
     if (this.soundOn) {
       this.eng.muffle(spb * 4, 520);
@@ -726,93 +971,94 @@ export class Game {
   }
 
   /* ---------------------------------------------------------------- */
-  /* breakdown / revive — the run never ends                           */
+  /* the heart — the run never stops, and it never rewinds             */
   /* ---------------------------------------------------------------- */
 
-  private enterBreakdown(): void {
-    this.phase = "breakdown";
-    this.charge = 0;
+  /**
+   * The heart ran out. **Nothing restarts.**
+   *
+   * The founder, on what shipped:
+   *
+   *   "the problem on 'restart the heart' doesn't have enough contrast, I don't
+   *    like that it 'restarts' .. 'restart the heart' an ok phrase but it
+   *    shouldn't take you back to the beginning. … I think the misses can get
+   *    counted that's fine and then you have to do math to go on .. but then it
+   *    should just go on and adjust and vary itself as you go on. … when you
+   *    have to do a math problem to go on it should flow with the regular game
+   *    and not be a reset."
+   *
+   * `enterBreakdown` did every single thing he is describing: it set a `phase`
+   * the transport refuses to plan in, called `flushNotes()` to delete every note
+   * in flight, ran `tapeStop` on the mix, put a modal over the field with a
+   * question drawn under a 72% black scrim, and — on the way out — called
+   * `reanchorSoft()`, which re-seats the transport at "now" and starts the cycle
+   * again. That is a reset, and a player who was struggling met it every fifteen
+   * seconds.
+   *
+   * What happens instead, and the whole of it:
+   *
+   *   1. the music KEEPS PLAYING, in tempo, with every note in flight intact;
+   *   2. a question is pulled forward so it arrives at the next reveal instead
+   *      of at the end of the cycle — the toll, "you have to do math to go on";
+   *   3. the world steps DOWN, because whatever it was doing was too much;
+   *   4. the heart stops draining while the debt stands, so there is no spiral;
+   *   5. answering — right OR wrong — clears the debt and the run continues from
+   *      exactly where it was, evolved rather than rewound.
+   *
+   * The phrase survives. `RESTART THE HEART` is drawn over the ordinary gate as
+   * a banner, on a field that never stopped moving.
+   */
+  private oweHeart(): void {
+    if (this.heartDebt) return;
+    this.heartDebt = true;
+    this.heartOuts++;
+    this.heart = 0;
     this.combo = 0;
-    this.flushNotes();
-    if (this.soundOn) this.eng.tapeStop(0.9);
-    this.host.haptic("heavy");
-    this.emit("breakdown", 1, null, true, 1);
-    this.kick(1.0, 1.06, 1);
+    this.perfectRun = 0;
 
-    const q = this.host.next({ difficulty: Math.max(1, Math.round(this.difficulty - 2)) });
-    const g = this.takeGate();
-    g.id = ++this.gateSeq;
-    g.active = true;
-    g.q = q;
-    g.time = 0;
-    g.revealAt = this.eng.now;
-    g.resolved = false;
-    g.correct = false;
-    g.answered = "";
-    g.shatter = 0;
-    g.crack = 0;
-    const sub = subdivisionFor(q.answer);
-    g.cells = sub ? sub.cells : null;
-    g.accentEvery = sub ? sub.accentEvery : 2;
-    const wrong = q.distractors.filter((d) => d !== q.answer).slice(0, 2);
-    while (wrong.length < 2) wrong.push(String(wrong.length + 1));
-    const lane = (this.gateSeq * 5) % 3 as Lane;
-    const labels: [string, string, string] = ["", "", ""];
-    labels[lane] = q.answer;
-    let w = 0;
-    for (let i = 0; i < 3; i++) if (i !== lane) labels[i] = wrong[w++]!;
-    g.labels = labels;
-    g.correctLane = lane;
-    this.reviveGate = g;
+    // Step the world down hard and take the estimates with it, so the ease
+    // survives the next few bars rather than being climbed straight back out of.
+    this.intensity = clamp(this.intensity - 0.18, SPLITBEAT_FLOW.floor, SPLITBEAT_FLOW.ceiling);
+    this.noteSuccess = Math.min(this.noteSuccess, SPLITBEAT_FLOW.strugglingBelow * 0.9);
+    this.applyDifficulty();
+
+    this.emit("heart-out", 1, null, true, 1);
+    this.host.haptic("heavy");
+    this.kick(0.9, 1.04, 0.7);
+    // A filter sweep and a duck, NOT a tape stop: the groove is still there,
+    // it has just gone underwater until the toll is paid.
+    if (this.soundOn) this.eng.muffle(((60 / this.bpm) * 4) * 2, 420);
+
+    this.pullGateForward();
   }
 
-  private answerRevive(lane: Lane): void {
-    const g = this.reviveGate;
-    if (!g || g.resolved) return;
-    const correct = lane === g.correctLane;
-    const ms = (this.eng.now - g.revealAt) * 1000;
-    g.resolved = true;
-    g.correct = correct;
-    g.answered = g.labels[lane]!;
-    this.gatesTotal++;
-    if (g.q) this.host.report({ questionId: g.q.id, correct, ms: Math.round(ms), answered: g.answered });
-
-    const t = this.eng.now;
-    if (correct) {
-      this.gatesCorrect++;
-      this.charge = MAX_CHARGE;
-      this.score += 800;
-      this.emit("revive", lane, null, true, 1);
-      this.host.haptic("success");
-      if (this.soundOn) {
-        this.eng.clearFilter(0.35);
-        this.eng.shatter(t, 1, 16);
-        this.eng.riser(t, 0.45, 1);
-        cadence(this.eng, t + 0.1, 60 / this.bpm, this.sector, true);
-      }
-      this.kick(1, 1.08, 0.9);
-    } else {
-      this.charge = 3;
-      this.adjustDifficulty(-1.6);
-      this.emit("gate-wrong", g.correctLane, null, true, 1);
-      this.host.haptic("failure");
-      if (this.soundOn) {
-        this.eng.clearFilter(0.6);
-        this.eng.impact(t, 0.8);
-        const dcells = g.cells ?? 4;
-        const spb = 60 / this.bpm;
-        for (let i = 0; i < Math.min(dcells, 8); i++) {
-          this.eng.bell(t + 0.3 + (i * spb * 4) / Math.min(dcells, 8), this.sector.root + 48, 0.45, 0.4, 0.6);
-        }
-      }
-      this.kick(1, 0.95, 0.7);
+  /**
+   * Bring the toll question to the front.
+   *
+   * If one is already on its way, THAT is the toll — it takes the banner and
+   * nothing is rescheduled. Marking it matters: the flag used to be written
+   * only at spawn, so a debt raised while a question was in flight was carried
+   * by no gate at all, and `expireGate` (which cleared the debt only for a
+   * flagged gate) then left `heartDebt` stuck true for the rest of the run.
+   *
+   * Otherwise the cycle is moved, not the transport: `roleOf` reads `bar -
+   * cycleStartBar`, so seating the cycle start `grooveBars - 1` bars back makes
+   * the next bar planned a reveal. No bar times move, no note is deleted, and
+   * nothing already scheduled into the audio graph is disturbed.
+   */
+  private pullGateForward(): void {
+    const g = this.activeGate;
+    if (g && !g.resolved) {
+      g.debt = true;
+      return;
     }
-    this.reviveGate = null;
-    this.activeGate = null;
-    this.phase = "playing";
-    this.applyDifficulty();
-    this.cells = clamp(this.cells, 2, this.maxCells);
-    this.reanchorSoft();
+    this.cycleStartBar = this.noteCursor - (this.grooveBars - 1);
+  }
+
+  private clearDebt(): void {
+    if (!this.heartDebt) return;
+    this.heartDebt = false;
+    if (this.soundOn) this.eng.clearFilter(0.35);
   }
 
   /* ---------------------------------------------------------------- */
@@ -825,10 +1071,6 @@ export class Game {
 
   /** `at` is an AudioContext-domain timestamp. */
   hit(lane: Lane, at: number): void {
-    if (this.phase === "breakdown") {
-      this.answerRevive(lane);
-      return;
-    }
     if (this.phase !== "playing") return;
 
     const t = this.judgeTime(at);
@@ -847,7 +1089,7 @@ export class Game {
     }
 
     if (best) {
-      const w = windowsFor(best.spacing);
+      const w = windowsForNote(best);
       const delta = t - best.time;
       const v = verdictFor(delta, w);
       if (v && v !== "miss") {
@@ -877,6 +1119,10 @@ export class Game {
     this.lastVerdict = v;
     this.lastJudgeAt = this.eng.now;
 
+    // The child's hand is the only thing that takes a held sum down, and only
+    // once it has settled. See `Reveal`.
+    this.dismissReveal();
+
     if (n.isChoice) {
       const g = this.gates.find((x) => x.active && x.id === n.gateId);
       // Every choice tile in the row is spent the moment one is struck.
@@ -896,8 +1142,13 @@ export class Game {
     this.combo++;
     if (this.combo > this.bestCombo) this.bestCombo = this.combo;
     this.perfectRun = v === "perfect" ? this.perfectRun + 1 : 0;
-    if (this.perfectRun > 0 && this.perfectRun % 12 === 0 && this.charge < MAX_CHARGE) {
-      this.charge++;
+    this.noteEvidence(true);
+    // Landing notes MENDS the heart. This is the half that was missing: the old
+    // charge could only ever go down between gates, so a beginner's meter was a
+    // countdown they had no way to stop.
+    const before = this.heart;
+    this.heart = clamp(this.heart + HEART_HIT, 0, 1);
+    if (Math.ceil(before * MAX_CHARGE - 1e-9) < Math.ceil(this.heart * MAX_CHARGE - 1e-9)) {
       this.emit("charge-up", n.lane, v, true, 1);
       if (this.soundOn) this.eng.chirp(this.eng.now, 700, 1500, 0.2, 0.7);
     }
@@ -925,12 +1176,29 @@ export class Game {
     this.fx.laneFlash[n.lane] = Math.min(1, this.fx.laneFlash[n.lane]! + 0.5 + mag * 0.5);
   }
 
+  /**
+   * A missed note is evidence, not just damage.
+   *
+   * The founder: *"If you keep sucking and losing then it should just get
+   * easier/stay easy."* `adjustDifficulty` moved on a GATE outcome and nothing
+   * else, so a player who never survived to reach a gate never received one
+   * gram of relief — which is the exact population the complaint is about. Every
+   * note, landed or not, now steers the controller.
+   */
+  private noteEvidence(landed: boolean): void {
+    const k = 1 / NOTE_WINDOW;
+    this.noteSuccess = clamp(this.noteSuccess + ((landed ? 1 : 0) - this.noteSuccess) * k, 0, 1);
+  }
+
   private registerMiss(n: Note, struck: boolean): void {
     n.state = 2;
     this.notesMissed++;
     this.combo = 0;
     this.perfectRun = 0;
-    this.charge -= 1;
+    this.noteEvidence(false);
+    // While a question is owed the heart is already spent and is not taken
+    // further: the toll is the question, not a spiral.
+    if (!this.heartDebt) this.heart = clamp(this.heart - HEART_MISS, 0, 1);
     this.lastVerdict = "miss";
     this.lastJudgeAt = this.eng.now;
     this.emit("miss", n.lane, "miss", n.accent, struck ? 0.7 : 1);
@@ -938,7 +1206,7 @@ export class Game {
     if (this.soundOn) this.eng.thud(this.eng.now, struck ? 0.7 : 1);
     this.kick(0.7, 0.985, 0.5);
     this.fx.vignette = Math.min(1, this.fx.vignette + 0.55);
-    if (this.charge <= 0) this.enterBreakdown();
+    if (this.heart <= 0) this.oweHeart();
   }
 
   /* ---------------------------------------------------------------- */
@@ -982,10 +1250,27 @@ export class Game {
 
     if (this.phase !== "playing") return;
 
+    /**
+     * The world moves toward what the evidence demands, every frame, in both
+     * directions. This is the "continuous evolution" half of the founder's
+     * note: nothing steps, nothing snaps, and a player who is struggling feels
+     * the whole thing — tempo, subdivision, note count, and the maths the host
+     * is asked for — breathe out together.
+     *
+     * Escalation is on ACHIEVEMENT, not the wall clock: `dt` only says how fast
+     * to travel toward a target that comes entirely from what was played.
+     */
+    this.intensity = settle(SPLITBEAT_FLOW, this.intensity, this.steer, dt);
+    this.flowDirty += dt;
+    if (this.flowDirty >= 5) {
+      this.flowDirty = 0;
+      saveFlow({ intensity: this.intensity, gateSuccess: this.gateSuccess, noteSuccess: this.noteSuccess });
+    }
+
     // Retire notes and register misses.
     for (const n of this.notes) {
       if (!n.active) continue;
-      const w = windowsFor(n.spacing);
+      const w = windowsForNote(n);
       if (n.state === 0 && now - n.time > w.miss) {
         if (n.isChoice) {
           const g = this.gates.find((x) => x.active && x.id === n.gateId);

--- a/dynawalla/games/rhythm/src/game/groove.test.ts
+++ b/dynawalla/games/rhythm/src/game/groove.test.ts
@@ -1,0 +1,185 @@
+/**
+ * THE GROOVE: does it fill three lanes, does it breathe both ways, and does it
+ * stop being the same tune?
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChartNote } from "./chart.ts";
+import {
+  barSignature,
+  CELL_LADDER,
+  cellCeiling,
+  evolve,
+  grooveBar,
+  laneOf,
+  metricWeight,
+  MIN_CELLS,
+  newGroove,
+  noteTarget,
+  ruleInto,
+} from "./groove.ts";
+
+const out: ChartNote[] = [];
+
+test("three lanes are reachable at every subdivision the evolution can choose", () => {
+  for (const cells of CELL_LADDER) {
+    if (cells < MIN_CELLS) continue;
+    const lanes = new Set<number>();
+    for (let c = 0; c < cells; c++) lanes.add(laneOf(c, cells));
+    assert.deepEqual(
+      [...lanes].sort(),
+      [0, 1, 2],
+      `a bar of ${cells} slices can only ever reach lanes ${[...lanes].sort().join(",")}`,
+    );
+  }
+});
+
+test("the lane quota puts a note in every lane from three notes upward", () => {
+  for (const cells of CELL_LADDER) {
+    if (cells < MIN_CELLS) continue;
+    for (let step = 0; step <= 10; step++) {
+      const intensity = step / 10;
+      const g = newGroove(cells * 977 + step);
+      g.cells = cells;
+      for (let bar = 0; bar < 24; bar++) {
+        grooveBar(g, intensity, out);
+        assert.ok(out.length >= 3, `${cells} slices at intensity ${intensity} produced ${out.length} notes`);
+        const lanes = new Set(out.map((n) => n.lane));
+        assert.equal(
+          lanes.size,
+          3,
+          `bar ${bar} at ${cells} slices, intensity ${intensity}, used only lanes ` +
+            `${[...lanes].sort().join(",")} — the top of the field is dead`,
+        );
+        evolve(g, intensity);
+      }
+    }
+  }
+});
+
+test("the note count rises with intensity and never drops below three", () => {
+  for (const cells of CELL_LADDER) {
+    let prev = -1;
+    for (let step = 0; step <= 10; step++) {
+      const n = noteTarget(cells, step / 10);
+      assert.ok(n >= 3 || n === cells, `${cells} slices at ${step / 10} wanted only ${n} notes`);
+      assert.ok(n >= prev, `the note count fell from ${prev} to ${n} as the intensity went UP`);
+      assert.ok(n <= cells, `${n} notes were asked for out of ${cells} slices`);
+      prev = n;
+    }
+  }
+  // …and the opening really is sparse. Three notes in a 4/4 bar at 92 BPM is
+  // one every 0.87 s, which is what a beginner can physically follow.
+  assert.equal(noteTarget(MIN_CELLS, 0), 3);
+  assert.ok(noteTarget(16, 1) >= 12, "the top of the range is not actually dense");
+});
+
+test("the subdivision ceiling rises with intensity and never falls below four", () => {
+  let prev = 0;
+  for (let step = 0; step <= 100; step++) {
+    const c = cellCeiling(step / 100);
+    assert.ok(c >= MIN_CELLS, `intensity ${step / 100} allowed a subdivision of ${c}`);
+    assert.ok(c >= prev, `the ceiling fell from ${prev} to ${c} as the intensity went UP`);
+    prev = c;
+  }
+  assert.equal(cellCeiling(0), MIN_CELLS);
+  assert.ok(cellCeiling(1) >= 16, `the top of the range only reaches ${cellCeiling(1)} slices`);
+});
+
+test("a falling intensity brings the subdivision back DOWN", () => {
+  const g = newGroove(4242);
+  for (let bar = 0; bar < 200; bar++) evolve(g, 1);
+  assert.ok(g.cells >= 12, `a run at full intensity only reached ${g.cells} slices`);
+  // Relief is not earned: it arrives on the same evolution step, not slower.
+  for (let bar = 0; bar < 40; bar++) evolve(g, 0);
+  assert.equal(g.cells, MIN_CELLS, `after forty bars of relief the world is still at ${g.cells} slices`);
+});
+
+test("a bar answered as halves is PLAYED as halves, and does not stay there", () => {
+  // The pedagogy: answer `1/2`, and the world re-rules itself into two.
+  const g = newGroove(9);
+  ruleInto(g, 2, 2, 0.5);
+  assert.equal(g.cells, 2, "the world did not re-rule itself into the answer");
+  // …but two slices cannot fill three lanes, so it climbs straight back out
+  // rather than leaving the top of the field dead for four bars.
+  evolve(g, 0);
+  assert.equal(g.cells, MIN_CELLS, "a two-slice world was allowed to persist");
+});
+
+test("metric weight is a groove, not a sprinkle: the downbeat outranks everything", () => {
+  for (const cells of CELL_LADDER) {
+    const w0 = metricWeight(0, cells);
+    for (let c = 1; c < cells; c++) {
+      assert.ok(w0 > metricWeight(c, cells), `slice ${c} of ${cells} outranked the downbeat`);
+    }
+  }
+  // A sixteenth is worth less than an "and", which is worth less than a beat.
+  assert.ok(metricWeight(1, 4) > metricWeight(1, 8));
+  assert.ok(metricWeight(1, 8) > metricWeight(1, 16));
+});
+
+test("the same groove state at the same intensity does not produce the same bar twice", () => {
+  const g = newGroove(31337);
+  g.cells = 8;
+  const seen = new Set<string>();
+  const seq: string[] = [];
+  for (let bar = 0; bar < 200; bar++) {
+    grooveBar(g, 0.5, out);
+    const sig = barSignature(out, g.cells);
+    seen.add(sig);
+    seq.push(sig);
+    evolve(g, 0.5);
+  }
+  assert.ok(seen.size >= 12, `200 bars produced only ${seen.size} distinct shapes`);
+  // No four-bar phrase repeats verbatim — that is the thing a player gets
+  // tired of, and it is a stronger claim than a count of distinct bars.
+  const phrases = new Map<string, number>();
+  for (let i = 0; i + 4 <= seq.length; i++) {
+    const k = seq.slice(i, i + 4).join("|");
+    phrases.set(k, (phrases.get(k) ?? 0) + 1);
+  }
+  assert.equal(Math.max(...phrases.values()), 1, "a four-bar phrase repeated inside 200 bars");
+});
+
+test("two runs from different seeds are different tunes", () => {
+  const a = newGroove(1);
+  const b = newGroove(2);
+  a.cells = 8;
+  b.cells = 8;
+  let same = 0;
+  for (let bar = 0; bar < 100; bar++) {
+    grooveBar(a, 0.6, out);
+    const sa = barSignature(out, a.cells);
+    grooveBar(b, 0.6, out);
+    const sb = barSignature(out, b.cells);
+    if (sa === sb) same++;
+    evolve(a, 0.6);
+    evolve(b, 0.6);
+  }
+  assert.ok(same < 60, `${same} of 100 bars were identical between two differently seeded runs`);
+});
+
+test("every note lands on its own slice, in its own lane, exactly once", () => {
+  for (const cells of CELL_LADDER) {
+    const g = newGroove(cells * 13);
+    g.cells = cells;
+    for (let bar = 0; bar < 60; bar++) {
+      // `evolve` moves the subdivision, so the bar's own `cells` is the truth —
+      // and a two-slice world is raised to four on the first step, deliberately.
+      const live = g.cells;
+      grooveBar(g, (bar % 11) / 10, out);
+      const seen = new Set<number>();
+      for (const n of out) {
+        assert.equal(n.cells, live, `a note claimed ${n.cells} slices in a bar of ${live}`);
+        assert.ok(!seen.has(n.cell), `slice ${n.cell} was struck twice in one bar of ${live}`);
+        seen.add(n.cell);
+        assert.equal(n.lane, laneOf(n.cell, live));
+        assert.ok(Math.abs(n.beat - (n.cell * 4) / live) < 1e-9, "a note left the grid");
+      }
+      assert.ok(out.some((n) => n.cell === 0), "the bar lost its downbeat");
+      evolve(g, (bar % 11) / 10);
+    }
+  }
+});

--- a/dynawalla/games/rhythm/src/game/groove.ts
+++ b/dynawalla/games/rhythm/src/game/groove.ts
@@ -1,0 +1,314 @@
+/**
+ * THE GROOVE THAT KEEPS EVOLVING.
+ *
+ * The founder, on the failure state and on what should replace it:
+ *
+ *   "Not start over into the same tune that you get tired of - continue into
+ *    further evolution adapting the difficulty. And we want to flex the
+ *    continuous evolution and variability."
+ *
+ * What shipped could not do that. `grooveBar` was seeded from `bar * 2654435761
+ * + cells * 40503` — deterministic in the bar index, which sounds like variety
+ * and is not: `cells` only ever changed when a child answered a gate with a
+ * musical denominator, so a measured four-minute run of an ordinary player
+ * produced ONE distinct bar shape, `cells: 4`, two hundred and twenty-two times.
+ * The top lane never received a single note, because at `cells: 4` every cell
+ * lands on a beat and only off-beat cells were routed there.
+ *
+ * ## What this is
+ *
+ * A small mutable `Groove` — the subdivision, the accent period, a rotation
+ * phase and a mutation seed — that the transport advances ONE STEP PER BAR. The
+ * step is stochastic, small, and bounded: the world drifts rather than jumping,
+ * so a bar always follows from the one before it, and two hundred bars later
+ * you are somewhere you have not been.
+ *
+ * ## The one knob
+ *
+ * `intensity` is the shared `game-pacing` scalar, [0,1], and it drives the
+ * subdivision AND the note count together. Both directions: a player who is
+ * missing notes watches the world thin out and slow down, which is the founder's
+ * "if you keep sucking and losing then it should just get easier/stay easy".
+ *
+ * ## The lane quota
+ *
+ * Notes are picked from the grid in METRIC WEIGHT order — a groove is not a
+ * random sprinkle and a child can tell — but from the third note onwards the
+ * pick is constrained so that every lane gets one. That is the fix for the
+ * empty top third, and it is a rule rather than a tuning: a drummer's hi-hat is
+ * the most CONSTANT voice in a beat, not the leftover after the kick and snare
+ * have taken what they want.
+ */
+
+import type { ChartNote, Lane } from "./chart.ts";
+
+/** Denominators that are also playable subdivisions of a 4/4 bar. */
+export const CELL_LADDER = [2, 4, 8, 6, 12, 16] as const;
+
+export type Groove = {
+  /** how many equal slices the bar — and the floor — is ruled into */
+  cells: number;
+  /** every nth slice is accented */
+  accentEvery: number;
+  /** rotation of the mutation mask, in cells; drifts so a motif does not sit still */
+  phase: number;
+  /** advanced every bar; the only source of per-bar variation */
+  seed: number;
+  /** bars since `cells` last changed — a subdivision is given time to be heard */
+  held: number;
+};
+
+export function newGroove(seed = 0x5eed1e): Groove {
+  return { cells: 4, accentEvery: 2, phase: 0, seed: seed >>> 0, held: 0 };
+}
+
+/** xorshift-ish step. Mutates `g.seed` and returns a float in [0,1). */
+function roll(g: Groove): number {
+  let a = (g.seed + 0x6d2b79f5) >>> 0;
+  g.seed = a;
+  let t = a;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+/**
+ * The deepest subdivision this intensity is allowed to reach.
+ *
+ * Never below FOUR, and that is a legibility constraint rather than a
+ * difficulty one: a bar cut into halves has two slices, so it has room for two
+ * notes, so it cannot put a note in each of the three lanes. Two of the three
+ * lanes standing empty is what the top of the field looked like for the whole
+ * opening of every run that ever shipped. `2` remains in the ladder because a
+ * child can answer `1/2` and must then get to PLAY halves — `ruleInto` — but
+ * the evolution never chooses it on its own.
+ */
+export const MIN_CELLS = 4;
+
+export function cellCeiling(intensity: number): number {
+  const i = intensity < 0 ? 0 : intensity > 1 ? 1 : intensity;
+  // Index into the ladder rather than a raw number, so every rung is a
+  // denominator a child can be asked about and can play.
+  const rung = Math.min(CELL_LADDER.length - 1, Math.floor(i * CELL_LADDER.length));
+  let ceil = MIN_CELLS;
+  for (let k = 0; k <= rung; k++) ceil = Math.max(ceil, CELL_LADDER[k]!);
+  return ceil;
+}
+
+/**
+ * How many notes a bar of `cells` carries at this intensity.
+ *
+ * The floor is THREE, and that is the survivability number: three notes in a
+ * 4/4 bar at 92 BPM is one note every 0.87 s, which is a half-time feel a
+ * beginner can physically follow, and it is exactly enough to put one note in
+ * each of the three lanes.
+ *
+ * A bar with fewer than three slices obviously cannot carry three notes, so the
+ * clamp to `cells` is applied LAST. Written the other way round it returned
+ * three notes for a two-slice bar, which the caller would then have had to
+ * silently drop — the kind of quiet disagreement between a target and a grid
+ * that is impossible to see from the outside.
+ */
+export function noteTarget(cells: number, intensity: number): number {
+  const i = intensity < 0 ? 0 : intensity > 1 ? 1 : intensity;
+  const full = Math.max(3, Math.round(cells * 0.82));
+  const n = Math.round(3 + (full - 3) * i);
+  return Math.min(Math.max(2, Math.round(cells)), Math.max(3, n));
+}
+
+/**
+ * Metric weight of a slice: how much a drummer wants a note there.
+ *
+ * Downbeat first, then beat 3, then the backbeats, then the "and"s, then the
+ * sixteenths. Ties are broken by the groove's live seed, which is what makes two
+ * bars at the same intensity and the same subdivision different bars.
+ */
+export function metricWeight(cell: number, cells: number): number {
+  const beat = (cell * 4) / cells;
+  const near = (x: number): boolean => Math.abs(beat - x) < 1e-9;
+  if (near(0)) return 100;
+  if (near(2)) return 90;
+  if (near(1) || near(3)) return 80;
+  if (Math.abs(beat - Math.round(beat)) < 1e-9) return 70;
+  if (Math.abs(beat * 2 - Math.round(beat * 2)) < 1e-9) return 55;
+  if (Math.abs(beat * 3 - Math.round(beat * 3)) < 1e-9) return 45;
+  return 35;
+}
+
+/**
+ * Which lane a slice belongs to. Kick low, snare mid, everything off the pulse
+ * rides the hat.
+ *
+ * This is the same metric-weight idea the shipped `laneFor` used, with one
+ * change: a bar that has no off-beat slices at all (`cells: 2`, `cells: 4`) used
+ * to leave lane 2 permanently empty, so the top third of the field was dead for
+ * the entire opening of every run. Now the SECOND half of an on-beat-only bar
+ * rides, which is a half-time feel rather than a hole.
+ */
+export function laneOf(cell: number, cells: number): Lane {
+  // A THREE-FEEL grid — 3 and 6 slices — has only two slices that land on a
+  // beat at all, and both of them are downbeat-family, so the on-beat rule
+  // below leaves lane 1 permanently empty. `groove.test.ts` catches it: "a bar
+  // of 6 slices can only ever reach lanes 0,2". Six is a rung the evolution
+  // genuinely visits, so this is not a corner case. The cycle of three is what
+  // a drummer plays over it, and it fills all three lanes by construction.
+  if (cells % 3 === 0 && cells % 4 !== 0) {
+    const m = cell % 3;
+    return m === 0 ? 0 : m === 1 ? 2 : 1;
+  }
+  const beat = (cell * 4) / cells;
+  const onBeat = Math.abs(beat - Math.round(beat)) < 1e-9;
+  if (!onBeat) return 2;
+  if (cells <= 2) return cell === 0 ? 0 : 1;
+  if (cells <= 4) {
+    // 0 -> kick, 1 -> snare, 2 -> kick, 3 -> ride
+    const b = Math.round(beat) % 4;
+    return b === 0 || b === 2 ? 0 : b === 1 ? 1 : 2;
+  }
+  const b = Math.round(beat) % 4;
+  return b === 0 || b === 2 ? 0 : 1;
+}
+
+/**
+ * One bar, chosen from the grid by weight with a lane quota.
+ *
+ * `out` is reused across bars — this runs on the planner's 22 ms timer and must
+ * not allocate.
+ */
+export function grooveBar(g: Groove, intensity: number, out: ChartNote[]): ChartNote[] {
+  out.length = 0;
+  const cells = Math.max(2, Math.round(g.cells));
+  const target = noteTarget(cells, intensity);
+
+  // Score every slice once. The jitter is small enough that it only ever
+  // reorders slices of the SAME weight class, so the groove stays a groove.
+  const scored: { cell: number; score: number; lane: Lane }[] = [];
+  for (let c = 0; c < cells; c++) {
+    const rotated = (c + g.phase) % cells;
+    const jitter = roll(g) * 9;
+    scored.push({
+      cell: c,
+      score: metricWeight(rotated, cells) + jitter,
+      lane: laneOf(c, cells),
+    });
+  }
+  scored.sort((a, b) => b.score - a.score);
+
+  const taken = new Set<number>();
+  const push = (cell: number): void => {
+    if (taken.has(cell)) return;
+    taken.add(cell);
+  };
+
+  // The downbeat always announces the bar.
+  push(0);
+  for (const s of scored) {
+    if (taken.size >= target) break;
+    push(s.cell);
+  }
+
+  // Lane quota: from three notes up, no lane may be empty. The cheapest slice
+  // that fixes it is swapped in for the weakest slice in an over-served lane.
+  if (target >= 3) {
+    for (let lane = 0 as Lane; lane < 3; lane = (lane + 1) as Lane) {
+      const has = [...taken].some((c) => laneOf(c, cells) === lane);
+      if (has) continue;
+      const want = scored.find((s) => s.lane === lane && !taken.has(s.cell));
+      if (!want) continue;
+      // drop the weakest taken slice from whichever lane has the most, never
+      // the downbeat
+      let drop = -1;
+      let dropScore = Infinity;
+      const count = [0, 0, 0];
+      for (const c of taken) count[laneOf(c, cells)]!++;
+      for (const s of scored) {
+        if (!taken.has(s.cell) || s.cell === 0) continue;
+        if (count[s.lane]! <= 1) continue;
+        if (s.score < dropScore) {
+          dropScore = s.score;
+          drop = s.cell;
+        }
+      }
+      if (drop >= 0) taken.delete(drop);
+      taken.add(want.cell);
+    }
+  }
+
+  const accentEvery = Math.max(1, Math.round(g.accentEvery));
+  for (const cell of [...taken].sort((a, b) => a - b)) {
+    out.push({
+      beat: (cell * 4) / cells,
+      lane: laneOf(cell, cells),
+      accent: cell % accentEvery === 0,
+      cell,
+      cells,
+    });
+  }
+  return out;
+}
+
+/**
+ * Advance the groove one bar.
+ *
+ * Three independent drifts, each one small:
+ *
+ *  - the ROTATION moves every few bars, which reshuffles which slices of a
+ *    weight class are favoured and so changes the motif without changing its
+ *    density or its subdivision;
+ *  - the ACCENT PERIOD wanders between 2, 3 and 4, which is where a bar stops
+ *    sounding like 4/4 and starts sounding like a tresillo;
+ *  - the SUBDIVISION follows `intensity`, but only ever by one rung and only
+ *    after the current one has been held for a few bars, so a child hears the
+ *    denominator they are playing before it becomes another one.
+ *
+ * `intensity` is the only outside input, which is what makes this the mechanism
+ * for "adjust and vary itself as you go on".
+ */
+export function evolve(g: Groove, intensity: number): void {
+  g.held++;
+
+  if (roll(g) < 0.34) g.phase = (g.phase + 1 + Math.floor(roll(g) * 2)) % Math.max(1, g.cells);
+
+  if (roll(g) < 0.16) {
+    const options = g.cells >= 8 ? [2, 3, 4] : g.cells >= 6 ? [2, 3] : [2, 4];
+    g.accentEvery = options[Math.floor(roll(g) * options.length)] ?? 2;
+  }
+
+  const ceil = cellCeiling(intensity);
+  // A world left ruled into halves by a `1/2` answer does not linger there:
+  // two slices cannot fill three lanes. One bar of it is the payoff; more is a
+  // hole in the top of the field.
+  if (g.cells < MIN_CELLS && g.held >= 1) {
+    g.cells = MIN_CELLS;
+    g.held = 0;
+    return;
+  }
+  if (g.held >= 4) {
+    const at = CELL_LADDER.indexOf(g.cells as (typeof CELL_LADDER)[number]);
+    const idx = at < 0 ? 1 : at;
+    if (g.cells > ceil) {
+      // Coming down is not made to wait. Relief is not earned.
+      g.cells = Math.max(MIN_CELLS, CELL_LADDER[Math.max(0, idx - 1)]!);
+      g.held = 0;
+    } else if (g.cells < ceil && roll(g) < 0.5) {
+      g.cells = CELL_LADDER[Math.min(CELL_LADDER.length - 1, idx + 1)]!;
+      g.held = 0;
+    }
+  }
+  if (g.accentEvery > g.cells) g.accentEvery = 2;
+}
+
+/** Re-rule the world into a denominator the child just answered with. */
+export function ruleInto(g: Groove, cells: number, accentEvery: number, intensity: number): void {
+  const ceil = cellCeiling(intensity);
+  g.cells = Math.max(2, Math.min(cells, Math.max(ceil, 4)));
+  g.accentEvery = Math.max(1, Math.min(accentEvery, g.cells));
+  g.held = 0;
+}
+
+/** A stable name for one bar's shape, for tests that measure variety. */
+export function barSignature(notes: readonly ChartNote[], cells: number): string {
+  let s = `${cells}:`;
+  for (const n of notes) s += `${n.cell}${n.accent ? "*" : ""}.`;
+  return s;
+}

--- a/dynawalla/games/rhythm/src/game/judge.ts
+++ b/dynawalla/games/rhythm/src/game/judge.ts
@@ -39,6 +39,29 @@ export function windowsFor(spacing: number): Windows {
   };
 }
 
+/**
+ * The windows on one of the three ANSWER tiles.
+ *
+ * `strikeSec` comes from `answerPlan(item)` and from nothing else — see
+ * `answer.ts` for why that matters — so unlike `windowsFor` this takes no
+ * spacing, consults no tempo, and cannot narrow because the run sped up. The
+ * four bands keep the same proportions the base windows have, so the verdict
+ * word a child sees on a tile means what it means everywhere else.
+ *
+ * `windowsFor` is deliberately NOT reused with `spacing = strikeSec * 2`: it
+ * clamps against `BASE_WINDOWS`, so every plan above ±205 ms would silently
+ * collapse back onto the motion constant this exists to escape.
+ */
+export function strikeWindows(strikeSec: number): Windows {
+  const s = Number.isFinite(strikeSec) && strikeSec > 0 ? strikeSec : BASE_WINDOWS.miss;
+  return {
+    perfect: s * (BASE_WINDOWS.perfect / BASE_WINDOWS.miss),
+    great: s * (BASE_WINDOWS.great / BASE_WINDOWS.miss),
+    good: s * (BASE_WINDOWS.good / BASE_WINDOWS.miss),
+    miss: s,
+  };
+}
+
 /** `delta` is (hitTime - noteTime); sign is kept by the caller for the meter. */
 export function verdictFor(delta: number, w: Windows): Verdict | null {
   const a = Math.abs(delta);

--- a/dynawalla/games/rhythm/src/game/memory.ts
+++ b/dynawalla/games/rhythm/src/game/memory.ts
@@ -1,0 +1,59 @@
+/**
+ * WHERE THE RUN LEFT OFF.
+ *
+ * SPLITBEAT had no persistence of any kind — not one `localStorage` call in the
+ * whole pack — so every run began at difficulty 1 and every scrap of adaptation
+ * a child earned was thrown away the moment they closed it. For a child who is
+ * struggling that is the worst possible arrangement: the game learns to be
+ * gentle over four minutes and then forgets, and tomorrow it starts by being
+ * too hard again. *"If you keep sucking and losing then it should just get
+ * easier/stay easy"* is a claim about days, not only about minutes.
+ *
+ * ONE small key. Packs share a single ~5 MB `localStorage` budget with the host
+ * origin, so this stores three floats and nothing else — no history, no run
+ * log, no scores.
+ *
+ * Every failure is LOUD. Private browsing, a full quota and a disabled storage
+ * partition all throw here, and a silent catch would turn "the adaptation is not
+ * sticking" into an unfalsifiable user report.
+ */
+
+const KEY = "dw.rhythm.flow.v1";
+
+export type FlowMemory = {
+  intensity: number;
+  gateSuccess: number;
+  noteSuccess: number;
+};
+
+const ok = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v);
+
+export function loadFlow(): FlowMemory | null {
+  let raw: string | null = null;
+  try {
+    raw = globalThis.localStorage?.getItem(KEY) ?? null;
+  } catch (err) {
+    console.warn("[splitbeat] could not read the remembered pace", err);
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Partial<FlowMemory>;
+    if (!ok(v.intensity) || !ok(v.gateSuccess) || !ok(v.noteSuccess)) {
+      console.warn("[splitbeat] remembered pace was malformed; starting fresh", raw);
+      return null;
+    }
+    return { intensity: v.intensity, gateSuccess: v.gateSuccess, noteSuccess: v.noteSuccess };
+  } catch (err) {
+    console.warn("[splitbeat] remembered pace would not parse; starting fresh", err);
+    return null;
+  }
+}
+
+export function saveFlow(m: FlowMemory): void {
+  try {
+    globalThis.localStorage?.setItem(KEY, JSON.stringify(m));
+  } catch (err) {
+    console.warn("[splitbeat] could not remember the pace for next time", err);
+  }
+}

--- a/dynawalla/games/rhythm/src/game/survival.test.ts
+++ b/dynawalla/games/rhythm/src/game/survival.test.ts
@@ -1,0 +1,615 @@
+/**
+ * CAN A BEGINNER SURVIVE THIS, AND DOES IT EVER TAKE THEM BACK TO THE START?
+ *
+ * The founder, who is a drummer and a mathematician: *"It's too hard. … I can't
+ * last more than a few seconds really. It should be easier to start."* And:
+ * *"it shouldn't take you back to the beginning … it should flow with the
+ * regular game and not be a reset … continue into further evolution adapting
+ * the difficulty."*
+ *
+ * Every bot here strikes through `game.hit(lane, audioTime)` — the same call the
+ * keyboard and the pointer make — on a hand-driven audio clock, so a four-minute
+ * run plays in milliseconds and every bar line lands exactly where it would on a
+ * device. Nothing forces a verdict, a heart level or a difficulty.
+ *
+ * Measured against `origin/main` before this branch, for the same bots:
+ *
+ *   | player   | run ended at | times |
+ *   |----------|--------------|-------|
+ *   | watching  |  3.14 s     |  74   |
+ *   | moderate  | 44.46 s     |  16   |
+ *
+ * "Ended" meaning `enterBreakdown()`: notes deleted, tape stop, modal, and a
+ * `reanchorSoft()` on the way out. The first question did not appear until
+ * 12.69 s, so the watching player never saw one.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { installFakeAudio } from "../dev/fakeAudio.ts";
+
+const audio = installFakeAudio();
+
+const { Game, SPLITBEAT_FLOW } = await import("./core.ts");
+const { createStubHost } = await import("../stubHost.ts");
+
+import type { Host, Question } from "../contract.ts";
+import { barSignature } from "./groove.ts";
+
+/** What the founder could not survive: a few seconds of merely watching. */
+const WATCHING_MUST_SURVIVE = 30;
+/** A player of moderate skill must be able to play for four minutes. */
+const MODERATE_MUST_SURVIVE = 240;
+
+const LONG_RUN_SEC = 240;
+
+type Bot = {
+  /** probability of even attempting a given ordinary note */
+  attempt: number;
+  /** timing error, in ms, uniform +/- */
+  jitterMs: number;
+  /** what the bot does at a gate */
+  gate: "right" | "wrong" | "never";
+};
+
+const WATCHING: Bot = { attempt: 0, jitterMs: 0, gate: "never" };
+const MODERATE: Bot = { attempt: 0.7, jitterMs: 55, gate: "right" };
+const FLAILING: Bot = { attempt: 0.15, jitterMs: 130, gate: "wrong" };
+
+type Run = {
+  seconds: number;
+  /** clock seconds at which the heart first ran out, or Infinity */
+  firstHeartOut: number;
+  heartOuts: number;
+  /** clock second the first question was readable */
+  firstQuestionAt: number;
+  /** every (item difficulty, delivered reading seconds) pair, in order */
+  itemVsWindow: [number, number][];
+  /** every (item difficulty, delivered strike half-window seconds) pair */
+  itemVsStrike: [number, number][];
+  intensity: number;
+  difficulty: number;
+  bpm: number;
+  minIntensity: number;
+  maxIntensity: number;
+  notesHit: number;
+  notesMissed: number;
+  /** the transport's bar index at the end — proves the clock never rewound */
+  bars: number;
+  /** every planned bar as (start, duration), in the order they were planned */
+  barSpans: [number, number][];
+  /** every distinct bar pattern the run produced, in order of first appearance */
+  patterns: string[];
+  patternSeq: string[];
+  reveals: number;
+  /** every distinct lane that ever received an ordinary note */
+  lanesUsed: Set<number>;
+  /** lanes that received a note in the FIRST four bars */
+  openingLanes: Set<number>;
+};
+
+function mulberry(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * `Game.start()` arms a `setInterval` for the planner, and node keeps its event
+ * loop — and therefore the whole test process — alive while one is pending. A
+ * test that throws before reaching `game.destroy()` therefore HANGS the runner
+ * rather than reporting a failure, which is the worst possible behaviour for an
+ * assertion: it looks identical to a slow test, and it takes the rest of the
+ * file with it. Found by mutation testing, when a deliberately broken build
+ * turned a two-second run into a four-minute timeout.
+ */
+function closing(game: InstanceType<typeof Game>): Disposable {
+  return { [Symbol.dispose]: () => game.destroy() };
+}
+
+/** A host that serves the pack's own generated questions, at the asked rung. */
+function realHost(seed: number, asked: number[]): Host {
+  const stub = createStubHost({ seed });
+  return {
+    next(opts): Question {
+      asked.push(opts?.difficulty ?? 0);
+      return stub.next(opts);
+    },
+    report() {},
+    haptic() {},
+    prefersReducedMotion: () => true,
+  };
+}
+
+async function run(bot: Bot, seconds: number, seed = 7, startDifficulty?: number): Promise<Run> {
+  const asked: number[] = [];
+  const game = new Game(realHost(seed, asked));
+  game.soundOn = false;
+  if (startDifficulty !== undefined) game.difficulty = startDifficulty;
+  const ctx = audio.latest();
+  await game.start();
+  using _ = closing(game);
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+  const rnd = mulberry(seed * 7919 + 13);
+
+  const out: Run = {
+    seconds,
+    firstHeartOut: Infinity,
+    heartOuts: 0,
+    firstQuestionAt: Infinity,
+    itemVsWindow: [],
+    itemVsStrike: [],
+    intensity: 0,
+    difficulty: 0,
+    bpm: 0,
+    minIntensity: Infinity,
+    maxIntensity: -Infinity,
+    notesHit: 0,
+    notesMissed: 0,
+    bars: 0,
+    barSpans: [],
+    patterns: [],
+    patternSeq: [],
+    reveals: 0,
+    lanesUsed: new Set(),
+    openingLanes: new Set(),
+  };
+  const seenPattern = new Set<string>();
+  const seenGate = new Set<number>();
+  const seenNote = new Set<number>();
+  const bar0 = game.barGrid.map(() => -99);
+  let prevDebt = false;
+  let prevReveal: unknown = null;
+
+  for (let i = 0; i < Math.round(seconds / 0.02); i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    const now = ctx.currentTime;
+
+    if (!prevDebt && game.heartDebt) {
+      out.heartOuts++;
+      if (out.firstHeartOut === Infinity) out.firstHeartOut = now;
+    }
+    prevDebt = game.heartDebt;
+    if (game.reveal && game.reveal !== prevReveal) out.reveals++;
+    prevReveal = game.reveal;
+
+    out.minIntensity = Math.min(out.minIntensity, game.intensity);
+    out.maxIntensity = Math.max(out.maxIntensity, game.intensity);
+
+    // A bar's pattern, sampled once, as it becomes current.
+    for (let k = 0; k < game.barGrid.length; k++) {
+      const bg = game.barGrid[k]!;
+      if (bg.t === bar0[k] || bg.t < 0) continue;
+      bar0[k] = bg.t;
+      out.bars++;
+      out.barSpans.push([bg.t, bg.dur]);
+      const inBar = game.notes
+        .filter((n) => n.active && !n.isChoice && n.time >= bg.t - 1e-9 && n.time < bg.t + bg.dur - 1e-9)
+        .sort((a, b) => a.time - b.time);
+      if (inBar.length === 0) continue;
+      for (const n of inBar) {
+        out.lanesUsed.add(n.lane);
+        if (out.bars <= 4) out.openingLanes.add(n.lane);
+      }
+      const sig = barSignature(
+        inBar.map((n) => ({ beat: 0, lane: n.lane, accent: n.accent, cell: n.cell, cells: n.cells })),
+        bg.cells,
+      );
+      out.patternSeq.push(sig);
+      if (!seenPattern.has(sig)) {
+        seenPattern.add(sig);
+        out.patterns.push(sig);
+      }
+    }
+
+    for (const g of game.gates) {
+      if (!g.active || seenGate.has(g.id) || !g.q) continue;
+      const tile = game.notes.find((n) => n.active && n.isChoice && n.gateId === g.id);
+      if (!tile) continue;
+      seenGate.add(g.id);
+      if (out.firstQuestionAt === Infinity) out.firstQuestionAt = g.revealAt;
+      out.itemVsWindow.push([g.q.difficulty, tile.time - g.revealAt]);
+      out.itemVsStrike.push([g.q.difficulty, tile.strikeSec]);
+    }
+
+    const due = now - 0.012;
+    for (const note of game.notes) {
+      if (!note.active || note.state !== 0) continue;
+      if (Math.abs(note.time - due) > 0.015) continue;
+      if (seenNote.has(note.time * 1e6 + note.lane)) continue;
+      if (note.isChoice) {
+        if (bot.gate === "never") continue;
+        if (note.correct !== (bot.gate === "right")) continue;
+        seenNote.add(note.time * 1e6 + note.lane);
+        game.hit(note.lane, note.time + 0.012);
+        continue;
+      }
+      seenNote.add(note.time * 1e6 + note.lane);
+      if (rnd() >= bot.attempt) continue;
+      game.hit(note.lane, note.time + ((rnd() * 2 - 1) * bot.jitterMs) / 1000 + 0.012);
+    }
+
+    game.update(0.02);
+  }
+
+  out.intensity = game.intensity;
+  out.difficulty = game.difficulty;
+  out.bpm = game.bpm;
+  out.notesHit = game.notesHit;
+  out.notesMissed = game.notesMissed;
+  return out;
+}
+
+/* -------------------------------------------------- 1. survivable from cold */
+
+test("a player who is merely WATCHING meets a question long before they meet a consequence", async () => {
+  const r = await run(WATCHING, LONG_RUN_SEC);
+
+  assert.ok(
+    Number.isFinite(r.firstQuestionAt),
+    "a watching player was never shown a question at all in four minutes",
+  );
+  assert.ok(
+    r.firstQuestionAt < 9,
+    `the first question did not appear until ${r.firstQuestionAt.toFixed(2)}s; on main it was ` +
+      `12.69 s and the run was already over by then`,
+  );
+  assert.ok(
+    r.firstHeartOut > WATCHING_MUST_SURVIVE,
+    `a player who touched nothing ran the heart out after ${r.firstHeartOut.toFixed(2)}s; on main ` +
+      `this was 3.14 s and the floor for it is ${WATCHING_MUST_SURVIVE}s`,
+  );
+  assert.ok(
+    r.firstQuestionAt < r.firstHeartOut,
+    `the consequence (${r.firstHeartOut.toFixed(2)}s) arrived before the first question ` +
+      `(${r.firstQuestionAt.toFixed(2)}s), so a beginner is punished before being taught`,
+  );
+});
+
+test("a player of MODERATE skill plays four minutes without the heart ever running out", async () => {
+  const r = await run(MODERATE, MODERATE_MUST_SURVIVE);
+
+  assert.ok(r.notesHit > 100, `the bot only landed ${r.notesHit} notes; it is not playing`);
+  assert.ok(r.notesMissed > 20, `the bot missed only ${r.notesMissed}; it is not a MODERATE player`);
+  assert.equal(
+    r.heartOuts,
+    0,
+    `a 70%-accurate player ran the heart out ${r.heartOuts} time(s) in four minutes; on main ` +
+      `the same bot broke down at 44.46 s and 16 times over the run`,
+  );
+});
+
+/* ------------------------------------------- 2. the failure state is not a reset */
+
+test("the heart running out does NOT stop the music, delete the field, or rewind the run", async () => {
+  const r = await run(WATCHING, LONG_RUN_SEC);
+  assert.ok(r.heartOuts > 0, "the heart never ran out, so this proves nothing — make the bot worse");
+
+  // On main this was `phase = "breakdown"`, which the planner refuses to plan
+  // in, plus `flushNotes()` and a `reanchorSoft()` on the way out.
+  const game = new Game(realHost(3, []));
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+  using _ = closing(game);
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+  const inner = game as unknown as { oweHeart(): void; noteCursor: number };
+
+  for (let i = 0; i < 600; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    game.update(0.02);
+  }
+  const barsBefore = inner.noteCursor;
+  const notesBefore = game.notes.filter((n) => n.active).length;
+  const timesBefore = game.notes.filter((n) => n.active).map((n) => n.time).sort((a, b) => a - b);
+  assert.ok(notesBefore > 0, "no notes were in flight, so nothing could be proven about deleting them");
+
+  inner.oweHeart();
+
+  assert.equal(game.phase, "playing", "the heart running out changed the phase — that IS the reset");
+  assert.equal(
+    game.notes.filter((n) => n.active).length,
+    notesBefore,
+    "notes in flight were deleted; the field must not be cleared",
+  );
+  assert.deepEqual(
+    game.notes.filter((n) => n.active).map((n) => n.time).sort((a, b) => a - b),
+    timesBefore,
+    "a note already in flight had its time moved; the transport must not be re-seated",
+  );
+  assert.ok(
+    inner.noteCursor >= barsBefore,
+    `the bar cursor went backwards, from ${barsBefore} to ${inner.noteCursor}`,
+  );
+
+  // …and the run keeps planning bars, which a "breakdown" phase would not.
+  for (let i = 0; i < 300; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    game.update(0.02);
+  }
+  assert.ok(
+    inner.noteCursor > barsBefore,
+    "the transport stopped planning bars after the heart ran out; the music has stopped",
+  );
+});
+
+test("the owed question is an ORDINARY gate, on the beat, in the lanes", async () => {
+  const game = new Game(realHost(5, []));
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+  using _ = closing(game);
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+  const inner = game as unknown as { oweHeart(): void };
+  for (let i = 0; i < 400; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    game.update(0.02);
+  }
+  inner.oweHeart();
+  assert.ok(game.heartDebt, "the debt was not raised");
+
+  let tiles = 0;
+  let banner: (typeof game.gates)[number] | undefined;
+  for (let i = 0; i < 2500 && tiles === 0; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    game.update(0.02);
+    const t = game.notes.filter((n) => n.active && n.isChoice);
+    if (t.length) {
+      tiles = t.length;
+      banner = game.gates.find((g) => g.active && g.id === t[0]!.gateId);
+    }
+  }
+  assert.equal(tiles, 3, `the owed question produced ${tiles} tiles instead of three lanes of one`);
+  assert.ok(banner, "the tiles belong to no gate");
+  assert.ok(banner!.debt, "the owed gate is not flagged, so RESTART THE HEART would not be drawn on it");
+  assert.ok(
+    banner!.time - banner!.revealAt >= 6,
+    `the owed question gave ${(banner!.time - banner!.revealAt).toFixed(2)}s to read; on main the ` +
+      `revive question appeared in a modal with no lead at all`,
+  );
+});
+
+test("a player who keeps running the heart out is never sent back to the beginning", async () => {
+  const r = await run(FLAILING, LONG_RUN_SEC);
+  assert.ok(r.heartOuts >= 2, `only ${r.heartOuts} heart-outs; this bot has to bottom out repeatedly`);
+  assert.ok(r.bars > 60, `only ${r.bars} bars were played in four minutes of flailing`);
+
+  // THE MUSIC IS CONTINUOUS. Every bar begins exactly where the one before it
+  // ended — no gap, no overlap, no re-seat. `reanchorSoft()`, which the old
+  // breakdown ran on its way out, sets the next bar to `now + LEAD_IN` and so
+  // opens a hole here; there is no way to restart a transport without one.
+  const spans = [...r.barSpans].sort((a, b) => a[0] - b[0]);
+  for (let i = 1; i < spans.length; i++) {
+    const [prevT, prevDur] = spans[i - 1]!;
+    const [t] = spans[i]!;
+    assert.ok(
+      Math.abs(t - (prevT + prevDur)) < 1e-6,
+      `bar ${i} starts at ${t.toFixed(3)}s but the bar before it ended at ` +
+        `${(prevT + prevDur).toFixed(3)}s — a ${(t - prevT - prevDur).toFixed(3)}s seam in the music`,
+    );
+  }
+  assert.ok(spans.length > 60, `only ${spans.length} bar spans were sampled`);
+});
+
+/* --------------------------------------------- 3. relief without reaching a gate */
+
+test("MISSING NOTES eases the game — the channel that did not exist", async () => {
+  // On main, `adjustDifficulty` moved on a gate outcome and nothing else, so a
+  // player who never survived to reach a gate never got one gram of relief.
+  const r = await run({ attempt: 0, jitterMs: 0, gate: "never" }, 120, 11, 9);
+  assert.ok(
+    r.difficulty < 5,
+    `a player who landed nothing and answered nothing ended at difficulty ${r.difficulty.toFixed(2)}, ` +
+      `having started at 9; missing notes must ease the game on their own`,
+  );
+  assert.ok(
+    r.minIntensity < 0.2,
+    `the world only ever came down to intensity ${r.minIntensity.toFixed(3)}`,
+  );
+});
+
+test("relief comes from the NOTES themselves, not only from bottoming the heart out", async () => {
+  // The test above passes even if per-note evidence is deleted, because running
+  // the heart out ALSO steps the world down — so it cannot tell the two apart.
+  // A 55%-accurate player never bottoms out, so this one can: every gram of the
+  // relief below came from notes being missed and from nothing else.
+  const r = await run({ attempt: 0.55, jitterMs: 40, gate: "never" }, 150, 17, 9);
+  assert.equal(
+    r.heartOuts,
+    0,
+    `the heart ran out ${r.heartOuts} time(s), so the relief could have come from there instead`,
+  );
+  assert.ok(r.notesMissed > 40, `only ${r.notesMissed} notes were missed; there is no evidence to act on`);
+  assert.ok(r.notesHit > 40, `only ${r.notesHit} notes were landed; this is not a struggling player`);
+  assert.ok(
+    r.difficulty < 4,
+    `a 55%-accurate player started at 9 and ended at ${r.difficulty.toFixed(2)} without ever ` +
+      `bottoming out; the per-note channel is not steering`,
+  );
+});
+
+test("LANDING notes keeps the heart, with no help from any question", async () => {
+  // The other half of the same mechanism, isolated the same way: this player
+  // answers nothing, so no gate can refill them. Only their own playing can.
+  const r = await run({ attempt: 0.8, jitterMs: 45, gate: "never" }, MODERATE_MUST_SURVIVE, 19);
+  assert.ok(r.notesMissed > 40, `only ${r.notesMissed} notes were missed; nothing was draining`);
+  assert.equal(
+    r.heartOuts,
+    0,
+    `an 80%-accurate player who never answered a question ran the heart out ${r.heartOuts} time(s); ` +
+      `landing a note has to put charge BACK, or the meter is a countdown with extra steps`,
+  );
+});
+
+test("the world comes DOWN and goes back UP on the same scalar", async () => {
+  const struggling = await run(FLAILING, LONG_RUN_SEC, 11, 8);
+  const thriving = await run({ attempt: 1, jitterMs: 8, gate: "right" }, LONG_RUN_SEC, 11, 2);
+
+  assert.ok(
+    struggling.difficulty < 4,
+    `a struggling run started at 8 and ended at ${struggling.difficulty.toFixed(2)}`,
+  );
+  assert.ok(
+    thriving.difficulty > 6,
+    `a thriving run started at 2 and only reached ${thriving.difficulty.toFixed(2)}`,
+  );
+  assert.ok(
+    struggling.bpm < thriving.bpm - 15,
+    `the two runs ended ${(thriving.bpm - struggling.bpm).toFixed(0)} BPM apart; the tempo is ` +
+      `supposed to breathe with the same scalar`,
+  );
+});
+
+/* --------------------------------------------------- 4. continuous variability */
+
+test("a long run does not repeat its tune", async () => {
+  const r = await run({ attempt: 1, jitterMs: 10, gate: "right" }, LONG_RUN_SEC);
+  assert.ok(r.patternSeq.length > 80, `only ${r.patternSeq.length} bars were sampled`);
+  assert.ok(
+    r.patterns.length >= 20,
+    `four minutes produced only ${r.patterns.length} distinct bar patterns out of ` +
+      `${r.patternSeq.length} bars; on main the same measurement produced ONE`,
+  );
+  // No eight-bar phrase repeats verbatim: the thing a player gets tired of is a
+  // loop, not a shortage of shapes.
+  const phrases = new Map<string, number>();
+  for (let i = 0; i + 8 <= r.patternSeq.length; i++) {
+    const key = r.patternSeq.slice(i, i + 8).join("|");
+    phrases.set(key, (phrases.get(key) ?? 0) + 1);
+  }
+  const worst = Math.max(...phrases.values());
+  assert.equal(worst, 1, `an eight-bar phrase repeated ${worst} times inside one run`);
+});
+
+test("every lane is playable from the very first bars", async () => {
+  const r = await run({ attempt: 1, jitterMs: 10, gate: "right" }, 60);
+  assert.deepEqual(
+    [...r.openingLanes].sort(),
+    [0, 1, 2],
+    `the opening used lanes ${[...r.openingLanes].sort().join(",")}; on main lane 2 (HIGH) got ZERO ` +
+      `notes at the opening, so the top third of the field was dead while the game killed you`,
+  );
+});
+
+/* ------------------------------------------------ 5. the window, as delivered */
+
+test("the DELIVERED reading window is exactly the item's plan, at every tempo", async () => {
+  const r = await run({ attempt: 1, jitterMs: 8, gate: "right" }, LONG_RUN_SEC);
+  assert.ok(r.itemVsWindow.length > 6, `only ${r.itemVsWindow.length} gates were measured`);
+  assert.ok(r.bpm > 120, `the tempo only reached ${r.bpm.toFixed(0)} BPM; the coupling would not show`);
+
+  const { answerPlan } = await import("./answer.ts");
+  for (const [difficulty, delivered] of r.itemVsWindow) {
+    const planned = answerPlan({ difficulty }).readSec;
+    assert.ok(
+      Math.abs(delivered - planned) < 1e-6,
+      `an item of difficulty ${difficulty.toFixed(3)} was planned ${planned.toFixed(3)}s of reading ` +
+        `and delivered ${delivered.toFixed(3)}s`,
+    );
+  }
+  for (const [difficulty, strike] of r.itemVsStrike) {
+    assert.equal(strike, answerPlan({ difficulty }).strikeSec);
+  }
+
+  // Sorted by item difficulty, the delivered windows must not fall.
+  const sorted = [...r.itemVsWindow].sort((a, b) => a[0] - b[0]);
+  let prev = -Infinity;
+  for (const [difficulty, delivered] of sorted) {
+    assert.ok(
+      delivered >= prev - 1e-9,
+      `a harder item (${difficulty.toFixed(3)}) was delivered ${delivered.toFixed(3)}s when an ` +
+        `easier one had already been given ${prev.toFixed(3)}s`,
+    );
+    prev = delivered;
+  }
+});
+
+/* ------------------------------------------------- 6. the reveal has no deadline */
+
+test("a wrong answer completes the sum in front of the child", async () => {
+  const r = await run({ attempt: 0, jitterMs: 0, gate: "wrong" }, LONG_RUN_SEC);
+  assert.ok(r.reveals > 0, "no sum was ever completed in front of the player");
+});
+
+test("a completed sum has NO deadline — two minutes of clock cannot take it down", async () => {
+  const { revealPlan, REVEAL_SETTLE_MS } = await import("../../../../packs/shared/game-pacing/index.ts");
+  const plan = revealPlan(SPLITBEAT_FLOW, 0);
+  assert.equal(plan.holdMs, Number.POSITIVE_INFINITY, "a shown reveal must never expire on its own");
+  assert.equal(plan.settleMs, REVEAL_SETTLE_MS);
+
+  const game = new Game(realHost(21, []));
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+  using _ = closing(game);
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+
+  // Play until a question's tiles are up, then strike a wrong one.
+  let struck = false;
+  for (let i = 0; i < 3000 && !struck; i++) {
+    ctx.currentTime += 0.02;
+    pump();
+    game.update(0.02);
+    const tile = game.notes.find(
+      (n) => n.active && n.isChoice && !n.correct && Math.abs(n.time - ctx.currentTime) < 0.03,
+    );
+    if (tile) {
+      game.hit(tile.lane, tile.time);
+      struck = true;
+    }
+  }
+  assert.ok(struck, "never reached a question to get wrong");
+  assert.ok(game.reveal, "a wrong answer did not complete the sum");
+  const held = game.reveal!;
+
+  // Two minutes of frames, with the planner deliberately NOT pumped so no new
+  // question can arrive. Nothing but the child may end this.
+  for (let i = 0; i < 6000; i++) {
+    ctx.currentTime += 0.02;
+    game.update(0.02);
+  }
+  assert.equal(
+    game.reveal,
+    held,
+    "the completed sum was taken down by the passage of time alone after 120 seconds",
+  );
+});
+
+test("a tap still in flight cannot eat the sum before it has settled", async () => {
+  const { REVEAL_SETTLE_MS } = await import("../../../../packs/shared/game-pacing/index.ts");
+  const game = new Game(realHost(23, []));
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+  using _ = closing(game);
+  const inner = game as unknown as {
+    reveal: unknown;
+    showReveal(g: unknown): void;
+    dismissReveal(): void;
+  };
+  const gate = game.gates[0]!;
+  gate.q = { id: "q", prompt: "7 + 5", answer: "12", distractors: ["11", "13"], domain: "add-sub", difficulty: 0.2 };
+  inner.showReveal(gate);
+  assert.ok(game.reveal, "the reveal was not put up");
+
+  // A hair inside the settle window: the sum survives.
+  ctx.currentTime += (REVEAL_SETTLE_MS - 1) / 1000;
+  inner.dismissReveal();
+  assert.ok(game.reveal, `a tap ${REVEAL_SETTLE_MS - 1}ms after the reveal took it down`);
+
+  // A hair outside: the child meant it.
+  ctx.currentTime += 0.002;
+  inner.dismissReveal();
+  assert.equal(game.reveal, null, "the child's own next note must be able to end it");
+});

--- a/dynawalla/games/rhythm/src/index.ts
+++ b/dynawalla/games/rhythm/src/index.ts
@@ -189,16 +189,18 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
         lines: [
           "Now and then a question appears at the top of the screen.",
           "Three notes come at you, one in each lane, and each one has an answer on it.",
-          "Tap the lane with the right answer when it reaches the line.",
-          "A right answer adds one block of charge, and the screen says SPLIT. A wrong one takes two blocks away.",
+          "Tap the lane with the right answer when it reaches the line. Take as long as you like — the tiles wait for you.",
+          "A right answer refills your charge, and the screen says SPLIT.",
+          "If you get one wrong the finished sum stays on screen. It waits there until you play your next note, so you can read it for as long as you want.",
         ],
       },
       {
         heading: "Charge",
         lines: [
-          "The five blocks near the top are your charge.",
-          "If they all run out the music breaks down and the screen says RESTART THE HEART. Answer one more question right and the music starts again.",
-          "The run never ends. You always get another go.",
+          "The five blocks near the top are your charge. Missing a note takes a little off. Hitting one puts a little back.",
+          "If they run out the screen says RESTART THE HEART and the next question comes early. The music keeps playing the whole time.",
+          "Answer that question and you carry straight on from where you were. Nothing goes back to the beginning, ever.",
+          "The game gets easier on its own when you are finding it hard, and only gets harder when you are finding it easy.",
         ],
       },
       {

--- a/dynawalla/games/rhythm/src/render/ink.ts
+++ b/dynawalla/games/rhythm/src/render/ink.ts
@@ -1,0 +1,226 @@
+/**
+ * WHAT THE QUESTION LANDS ON.
+ *
+ * The founder, on the failure screen: *"the problem on 'restart the heart'
+ * doesn't have enough contrast."*
+ *
+ * He is right, and the number is **2.30:1**. Here is how it happened, because
+ * the mechanism matters more than the fix: `drawHud` painted the question in
+ * `#ffffff` inside an `rgba(4,6,18,0.82)` box — **19.78:1**, one of the most
+ * legible things in the pack — and then, thirty lines further down, the
+ * breakdown overlay painted `rgba(3,4,12,0.72)` **over the entire canvas**,
+ * question included. The white glyph composited down to `rgb(74,74,80)` and the
+ * box under it to `rgb(4,5,16)`. Nobody chose a low-contrast colour. The
+ * contrast was destroyed by a later draw call, which is exactly the class of
+ * defect that eyeballing a palette cannot find and measuring a composite can.
+ *
+ * (`games/balance/src/ink.ts` found the same class of thing on its brass
+ * weights, by the same method. The generic half of both files — `luma`,
+ * `contrast`, `over`, `plus`, and the two bars — is now written twice and
+ * should be lifted into `packs/shared`; see the PR.)
+ *
+ * ## The two bars
+ *
+ *   1. **Letterform, 4.5:1.** The glyph against the panel that rings it. WCAG AA
+ *      body text, held at the body-text number rather than the 3:1 large-text
+ *      allowance because the reader is a child doing arithmetic under time.
+ *   2. **Object, 3.0:1.** The panel against whatever it is lying on. WCAG 1.4.11
+ *      non-text contrast.
+ *
+ * Everything below is built from the same literals the renderer paints with, in
+ * the same order, with the same alphas — so a future scrim cannot be added
+ * without this file's numbers moving.
+ */
+
+export type RGB = readonly [number, number, number];
+
+/** Glyph against the panel behind it. WCAG AA body text. */
+export const MIN_LETTERFORM = 4.5;
+/** Panel against the ground it lies on. WCAG 1.4.11 non-text contrast. */
+export const MIN_OBJECT = 3.0;
+
+export function luma(c: RGB): number {
+  const f = (v: number): number => {
+    const x = v / 255;
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2]);
+}
+
+/** WCAG contrast ratio between two opaque colours, 1..21. */
+export function contrast(a: RGB, b: RGB): number {
+  const la = luma(a);
+  const lb = luma(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** `globalCompositeOperation = "source-over"` at `alpha`. */
+export function over(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.round(src[i]! * alpha + dst[i]! * (1 - alpha));
+  return [m(0), m(1), m(2)];
+}
+
+/** `globalCompositeOperation = "lighter"` at `alpha` — additive, clamped. */
+export function plus(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.min(255, Math.round(src[i]! * alpha + dst[i]!));
+  return [m(0), m(1), m(2)];
+}
+
+/* ------------------------------------------------------- the shipped literals */
+
+/** `drawHud`: the question panel, `roundRect` + `fill`. */
+export const PROMPT_PANEL: RGB = [4, 6, 18];
+export const PROMPT_PANEL_ALPHA = 0.82;
+
+/**
+ * …and the stroke around it.
+ *
+ * **The object bar is carried by this and not by the panel, and that is
+ * arithmetic rather than a preference.** The panel is a near-black
+ * `rgb(4,6,18)`; the violet sector's sky top is `rgb(15,5,28)`, whose relative
+ * luminance is 0.0029 against the panel's 0.0020. Those are 1.01:1 apart, and
+ * NO opacity fixes it — at alpha 1.0 the panel is still 1.02:1, because the two
+ * colours are simply the same darkness. A near-black panel cannot separate
+ * itself from a near-black sky by being more of a panel.
+ *
+ * So the panel is measured the way `games/balance/src/ink.ts` measures an inked
+ * blob: the better of its two edges. The stroke is a bright accent at 55% over
+ * whatever is behind it, and IT is what a reader's eye finds the box by. Every
+ * sector's `horizon` is therefore part of this claim, which is the right
+ * coupling — warm up a sector's accent and this number moves.
+ *
+ * **0.9, raised from the shipped 0.55, because the shipped value did not clear
+ * the bar.** The measurement, per sector, at the panel's best edge:
+ *
+ *   | stroke alpha | worst  | where  |
+ *   |--------------|--------|--------|
+ *   | 0.55 (shipped) | 2.68:1 | violet |
+ *   | 0.70         | 3.44:1 | violet |
+ *   | 0.90         | 4.57:1 | solar  |
+ *
+ * The violet sector is the hard one: its sky bottom takes an additive bloom of
+ * `rgb(170,70,255)` and lands at `rgb(79,27,126)`, which is close enough to its
+ * own `rgb(214,150,255)` accent that a 55% border almost disappears into it.
+ * Nobody would have found that by looking at the indigo sector, which is where
+ * every run starts.
+ */
+export const PROMPT_STROKE_ALPHA = 0.9;
+
+/** `drawNotes`: an answer tile's panel. */
+export const TILE_PANEL: RGB = [6, 9, 22];
+export const TILE_PANEL_ALPHA = 0.93;
+
+/** Every glyph in the gate surface is painted in this. */
+export const GLYPH: RGB = [255, 255, 255];
+
+/**
+ * The scrim the deleted breakdown overlay laid over the finished canvas.
+ *
+ * Kept, unused by the renderer, precisely so `legibility.test.ts` can measure
+ * what it did and fail if anything ever puts it back.
+ */
+export const DEAD_BREAKDOWN_SCRIM: RGB = [3, 4, 12];
+export const DEAD_BREAKDOWN_SCRIM_ALPHA = 0.72;
+
+/**
+ * Every sky a gate can be read against.
+ *
+ * The renderer paints a vertical gradient from `skyTop` to `skyBottom` per
+ * sector, and a gate can be on screen in any of them, so all twelve stops are
+ * ground. Taken from `theme.ts` rather than re-typed: warming up a sector must
+ * move these numbers.
+ */
+export type SectorSurfaces = {
+  id: string;
+  /** every ground a gate can be read against IN THIS SECTOR */
+  grounds: RGB[];
+  /** the accent this sector strokes and glows with */
+  accent: RGB;
+};
+
+/**
+ * The skies, GROUPED BY SECTOR.
+ *
+ * Grouping is not tidiness. The panel's stroke is `rgba(th.horizon, …)` — the
+ * CURRENT sector's accent — so a sector's sky is only ever seen behind its own
+ * accent. Measuring every accent against every sky invents pairings the
+ * renderer cannot produce, and a first draft of the legibility test did exactly
+ * that and reported a 2.75:1 that no player can ever be shown.
+ */
+export function sectors(
+  themes: Record<string, { skyTop: RGB; skyBottom: RGB; horizon: RGB; bloom: RGB }>,
+): SectorSurfaces[] {
+  return Object.entries(themes).map(([id, t]) => ({
+    id,
+    // the bloom haze behind the strike column is additive at its strongest
+    grounds: [t.skyTop, t.skyBottom, plus(t.bloom, t.skyBottom, 0.22)],
+    accent: t.horizon,
+  }));
+}
+
+/** Every ground in every sector, flattened — for claims that are accent-free. */
+export function skies(themes: Record<string, { skyTop: RGB; skyBottom: RGB; horizon: RGB; bloom: RGB }>): RGB[] {
+  return sectors(themes).flatMap((s) => s.grounds);
+}
+
+/** The panel the question is actually read on, over each sky. */
+export function promptPanels(sky: readonly RGB[]): RGB[] {
+  return sky.map((s) => over(PROMPT_PANEL, s, PROMPT_PANEL_ALPHA));
+}
+
+/** The panel an answer tile's label is read on, over each sky. */
+export function tilePanels(sky: readonly RGB[], laneColors: readonly RGB[]): RGB[] {
+  const out: RGB[] = [];
+  for (const s of sky) {
+    for (const lane of laneColors) {
+      // the lane's glow sprite is drawn additively under the panel at 0.45
+      const lit = plus(lane, s, 0.45);
+      out.push(over(TILE_PANEL, lit, TILE_PANEL_ALPHA));
+    }
+    out.push(over(TILE_PANEL, s, TILE_PANEL_ALPHA));
+  }
+  return out;
+}
+
+/** Put a scrim over an already-composited surface AND over the glyph on it. */
+export function underScrim(panel: RGB, glyph: RGB, scrim: RGB, alpha: number): { panel: RGB; glyph: RGB } {
+  return { panel: over(scrim, panel, alpha), glyph: over(scrim, glyph, alpha) };
+}
+
+/** The worst letterform contrast this glyph has over any of `panels`. */
+export function worstLetterform(glyph: RGB, panels: readonly RGB[]): number {
+  let worst = Infinity;
+  for (const p of panels) worst = Math.min(worst, contrast(glyph, p));
+  return worst;
+}
+
+/**
+ * The worst object contrast a bordered panel presents over its grounds.
+ *
+ * Per ground, the BETTER of the two edges — the fill's own contrast or the
+ * stroke's — because a bordered box is found by whichever of the two separates.
+ * See `PROMPT_STROKE_ALPHA` for why the fill alone provably cannot.
+ */
+export function worstPanelEdge(
+  sectorList: readonly SectorSurfaces[],
+  fill: RGB,
+  fillAlpha: number,
+  strokeAlpha: number,
+): { ratio: number; sector: string } {
+  let worst = Infinity;
+  let where = "";
+  for (const sec of sectorList) {
+    const stroke = over(sec.accent, [0, 0, 0], 1);
+    for (const s of sec.grounds) {
+      const best = Math.max(
+        contrast(over(fill, s, fillAlpha), s),
+        contrast(over(stroke, s, strokeAlpha), s),
+      );
+      if (best < worst) {
+        worst = best;
+        where = sec.id;
+      }
+    }
+  }
+  return { ratio: worst, sector: where };
+}

--- a/dynawalla/games/rhythm/src/render/legibility.test.ts
+++ b/dynawalla/games/rhythm/src/render/legibility.test.ts
@@ -1,0 +1,213 @@
+/**
+ * IS THE QUESTION READABLE, MEASURED FROM THE COMPOSITE?
+ *
+ * The founder, on the failure screen: *"the problem on 'restart the heart'
+ * doesn't have enough contrast."*
+ *
+ * Nobody had chosen a bad colour. `drawHud` painted the question white inside an
+ * `rgba(4,6,18,0.82)` panel — the most legible surface in the pack — and then the
+ * breakdown overlay painted `rgba(3,4,12,0.72)` over the WHOLE canvas, question
+ * included. The tests below reproduce that composite, prove it measured 2.30:1,
+ * and prove the shipped surfaces clear the bars without it.
+ *
+ * This is why the numbers are computed and not eyeballed: the defect was not in
+ * any colour, it was in the order of two draw calls thirty lines apart.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { LANE_COLOR, SECTOR_THEME } from "../theme.ts";
+import {
+  contrast,
+  DEAD_BREAKDOWN_SCRIM,
+  DEAD_BREAKDOWN_SCRIM_ALPHA,
+  GLYPH,
+  MIN_LETTERFORM,
+  MIN_OBJECT,
+  over,
+  PROMPT_PANEL,
+  PROMPT_PANEL_ALPHA,
+  PROMPT_STROKE_ALPHA,
+  promptPanels,
+  skies,
+  TILE_PANEL,
+  TILE_PANEL_ALPHA,
+  tilePanels,
+  underScrim,
+  worstLetterform,
+  worstPanelEdge,
+  sectors,
+  type RGB,
+} from "./ink.ts";
+
+type ThemeMap = Record<string, { skyTop: RGB; skyBottom: RGB; horizon: RGB; bloom: RGB }>;
+const SKY = skies(SECTOR_THEME as unknown as ThemeMap);
+const SECTORS = sectors(SECTOR_THEME as unknown as ThemeMap);
+
+test("the sky catalogue is the real one, not a snapshot that can go stale", () => {
+  // Three surfaces per sector; if a sector is added or a sky is warmed up, this
+  // moves, and so does every number below it.
+  assert.equal(SKY.length, Object.keys(SECTOR_THEME).length * 3);
+  assert.ok(SKY.length >= 18, `only ${SKY.length} sky surfaces were catalogued`);
+});
+
+test("the question clears the letterform bar on every sky the game has", () => {
+  const panels = promptPanels(SKY);
+  const worst = worstLetterform(GLYPH, panels);
+  assert.ok(
+    worst >= MIN_LETTERFORM,
+    `the question measures ${worst.toFixed(2)}:1 against its panel at worst; the bar is ${MIN_LETTERFORM}:1`,
+  );
+  // …and it is not scraping past. State the real number so a regression is
+  // visible as a change rather than as a pass.
+  assert.ok(worst > 15, `the question measures only ${worst.toFixed(2)}:1; it used to measure 19.78:1`);
+});
+
+test("the SHIPPED 0.55 stroke did not clear the object bar — this is a fix, not a formality", () => {
+  const was = worstPanelEdge(SECTORS, PROMPT_PANEL, PROMPT_PANEL_ALPHA, 0.55);
+  assert.ok(
+    was.ratio < MIN_OBJECT,
+    `the stroke that shipped measured ${was.ratio.toFixed(2)}:1, which clears the bar — then raising ` +
+      `it to ${PROMPT_STROKE_ALPHA} was unnecessary and this file is overstating its case`,
+  );
+  assert.equal(was.sector, "violet", `the worst sector moved to ${was.sector}`);
+});
+
+test("the question's panel is FOUND against every sky — by its stroke, because its fill cannot", () => {
+  const worst = worstPanelEdge(SECTORS, PROMPT_PANEL, PROMPT_PANEL_ALPHA, PROMPT_STROKE_ALPHA);
+  assert.ok(
+    worst.ratio >= MIN_OBJECT,
+    `the question panel measures ${worst.ratio.toFixed(2)}:1 at its best edge in the ` +
+      `${worst.sector} sector; the bar is ${MIN_OBJECT}:1`,
+  );
+
+  // …and the fill alone provably cannot do it, at ANY opacity. This is the
+  // reason the stroke is load-bearing rather than decorative, and it is stated
+  // as a measurement so nobody deletes the border to tidy the design up.
+  let bestFillOnly = 0;
+  for (let a = 0; a <= 100; a++) {
+    let w = Infinity;
+    for (const s of SKY) w = Math.min(w, contrast(over(PROMPT_PANEL, s, a / 100), s));
+    bestFillOnly = Math.max(bestFillOnly, w);
+  }
+  assert.ok(
+    bestFillOnly < MIN_OBJECT,
+    `an unstroked panel reaches ${bestFillOnly.toFixed(2)}:1 at its best opacity, which clears the ` +
+      `${MIN_OBJECT}:1 bar — the claim that the stroke is necessary is wrong`,
+  );
+});
+
+test("an answer tile's label clears the letterform bar, glow included", () => {
+  const panels = tilePanels(SKY, LANE_COLOR as readonly RGB[]);
+  const worst = worstLetterform(GLYPH, panels);
+  assert.ok(
+    worst >= MIN_LETTERFORM,
+    `an answer tile's label measures ${worst.toFixed(2)}:1 at worst against its panel`,
+  );
+});
+
+/* --------------------------------------------------------- the deleted scrim */
+
+test("the deleted breakdown scrim measured 2.30:1 — this is the founder's report, as a number", () => {
+  // The exact composite the shipped code produced: panel over sky, glyph over
+  // panel, and then the full-canvas scrim over BOTH.
+  let worst = Infinity;
+  let best = 0;
+  for (const s of SKY) {
+    const panel = promptPanels([s])[0]!;
+    const under = underScrim(panel, GLYPH, DEAD_BREAKDOWN_SCRIM, DEAD_BREAKDOWN_SCRIM_ALPHA);
+    const c = contrast(under.glyph, under.panel);
+    worst = Math.min(worst, c);
+    best = Math.max(best, c);
+  }
+  assert.ok(
+    best < MIN_LETTERFORM,
+    `the scrimmed question measured ${best.toFixed(2)}:1 at its BEST, which would clear the ` +
+      `${MIN_LETTERFORM}:1 bar — the reproduction of the defect is wrong`,
+  );
+  assert.ok(
+    best < MIN_OBJECT,
+    `the scrimmed question measured ${best.toFixed(2)}:1 at best, above even the ${MIN_OBJECT}:1 ` +
+      `non-text bar`,
+  );
+  // Pin the number the report was about.
+  assert.ok(
+    Math.abs(worst - 2.3) < 0.05,
+    `the scrimmed question measured ${worst.toFixed(2)}:1; the reported figure is 2.30:1`,
+  );
+});
+
+test("removing the scrim is what fixed it — the same panel, unscrimmed, is 8x better", () => {
+  const s = SKY[0]!;
+  const panel = promptPanels([s])[0]!;
+  const clean = contrast(GLYPH, panel);
+  const scrimmed = underScrim(panel, GLYPH, DEAD_BREAKDOWN_SCRIM, DEAD_BREAKDOWN_SCRIM_ALPHA);
+  const dirty = contrast(scrimmed.glyph, scrimmed.panel);
+  assert.ok(
+    clean / dirty > 8,
+    `the scrim only cost ${(clean / dirty).toFixed(1)}x (${clean.toFixed(2)}:1 -> ${dirty.toFixed(2)}:1)`,
+  );
+});
+
+test("NO full-canvas scrim is drawn over the question any more", async () => {
+  // The mechanism, asserted directly rather than through its consequences: a
+  // `fillRect` covering the whole canvas, painted after the question, is the
+  // defect. There is exactly one such call left in the renderer — the white
+  // flash — and it is rate-limited, amplitude-capped, and drawn BEFORE the HUD.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("./renderer.ts", import.meta.url), "utf8");
+  const hud = src.slice(src.indexOf("private drawHud("));
+  assert.ok(hud.length > 500, "drawHud was not found; this test is measuring nothing");
+  assert.equal(
+    hud.includes("fillRect(0, 0, this.W, this.H)"),
+    false,
+    "a full-canvas fillRect is back inside drawHud, where the question is drawn",
+  );
+  assert.equal(
+    src.includes("RESTART THE HEART"),
+    true,
+    "the phrase the founder likes was dropped along with the modal",
+  );
+});
+
+/* ------------------------------------------------------------ the guard rail */
+
+test("a hypothetical scrim of ANY strength over the question is caught by the maths", () => {
+  // The bars are not decoration: they reject the defect at every alpha that
+  // would actually have been used. 0.2 is a light dim and 0.72 is what shipped.
+  const s = SKY[0]!;
+  const panel = promptPanels([s])[0]!;
+  const failing: number[] = [];
+  const passing: number[] = [];
+  for (const alpha of [0.2, 0.3, 0.4, 0.5, 0.6, 0.72, 0.85]) {
+    const u = underScrim(panel, GLYPH, DEAD_BREAKDOWN_SCRIM, alpha);
+    (contrast(u.glyph, u.panel) < MIN_LETTERFORM ? failing : passing).push(alpha);
+  }
+  // The cliff is between 0.5 and 0.6, and it is worth stating where it is
+  // rather than only that it exists: a first draft of this test asserted 0.5
+  // was unacceptable, ran, and found out otherwise. A 50% dim over the
+  // question measures 5.19:1 and is genuinely fine. What shipped was 0.72.
+  assert.deepEqual(failing, [0.6, 0.72, 0.85], `the cliff moved: failing at ${failing.join(", ")}`);
+  assert.deepEqual(passing, [0.2, 0.3, 0.4, 0.5], `the cliff moved: passing at ${passing.join(", ")}`);
+});
+
+test("the panel alphas the renderer paints with are the ones measured here", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("./renderer.ts", import.meta.url), "utf8");
+  const prompt = `rgba(${PROMPT_PANEL.join(",")},${PROMPT_PANEL_ALPHA})`;
+  const tile = `rgba(${TILE_PANEL.join(",")},${TILE_PANEL_ALPHA})`;
+  assert.ok(src.includes(prompt), `the renderer no longer paints the question panel as ${prompt}`);
+  assert.ok(src.includes(tile), `the renderer no longer paints an answer tile as ${tile}`);
+  // The stroke alpha is IMPORTED by the renderer rather than re-typed, which is
+  // the only way the measured number and the painted number cannot drift.
+  assert.ok(
+    src.includes("rgba(th.horizon, PROMPT_STROKE_ALPHA)"),
+    "the renderer went back to a literal stroke alpha, so this file's 4.57:1 is now a claim about nothing",
+  );
+  assert.equal(
+    src.includes("rgba(th.horizon, 0.55)"),
+    false,
+    "the 0.55 stroke that measured 2.68:1 in the violet sector is back",
+  );
+});

--- a/dynawalla/games/rhythm/src/render/renderer.ts
+++ b/dynawalla/games/rhythm/src/render/renderer.ts
@@ -24,6 +24,7 @@ import {
 } from "../theme.ts";
 import { safeInsets, safeRect } from "../../../../packs/shared/game-chrome/index.ts";
 import { layoutFor, LEAD, type Layout } from "./layout.ts";
+import { PROMPT_STROKE_ALPHA } from "./ink.ts";
 import { drawRich, measureRich } from "./typeset.ts";
 import {
   Particles, PAL_BLOOM, PAL_DIM, PAL_GOLD, PAL_HORIZON, PAL_WHITE,
@@ -329,7 +330,7 @@ export class Renderer {
           this.bigFlash(now, 0.36);
           break;
         }
-        case "breakdown":
+        case "heart-out":
           this.particles.burst(this.strikeX, this.playTop + this.playH / 2, this.spec.sparks >> 2, PAL_DIM, 700, rnd, false);
           break;
         case "revive":
@@ -663,7 +664,7 @@ export class Renderer {
     const H = this.playH;
 
     for (const gate of g.gates) {
-      if (!gate.active || gate === g.reviveGate) continue;
+      if (!gate.active) continue;
       // the slab rides just behind the tiles
       const sx = this.xAt(gate.time + 0.14, now);
       if (sx < -this.W || sx > this.W * 2) continue;
@@ -891,17 +892,30 @@ export class Renderer {
     // --- charge ------------------------------------------------------
     const cellW = lay.chargeCellW;
     const cx0 = lay.chargeX;
+    // The heart is continuous now — a miss takes a slice off, a landed note puts
+    // one back — so the block it is currently inside fills PARTIALLY. The state
+    // lives in the design rather than in a number: a player watching the last
+    // block drain can see they are recovering it, which is the whole difference
+    // between the meter reading as a countdown and reading as something you are
+    // playing against.
     for (let i = 0; i < 5; i++) {
-      const on = i < g.charge;
+      const fill = Math.max(0, Math.min(1, g.charge - i));
       const x = cx0 + i * (cellW + u * 0.1);
-      ctx.fillStyle = on ? rgba(th.horizon, 0.95) : "rgba(255,255,255,0.13)";
+      ctx.fillStyle = "rgba(255,255,255,0.13)";
       this.roundRect(ctx, x, lay.chargeY, cellW, lay.chargeCellH, u * 0.16);
       ctx.fill();
-      if (!on) {
+      if (fill < 1) {
         ctx.strokeStyle = "rgba(255,255,255,0.22)";
         ctx.lineWidth = 1;
         ctx.stroke();
       }
+      if (fill <= 0) continue;
+      ctx.save();
+      this.roundRect(ctx, x, lay.chargeY, cellW, lay.chargeCellH, u * 0.16);
+      ctx.clip();
+      ctx.fillStyle = rgba(th.horizon, 0.95);
+      ctx.fillRect(x, lay.chargeY, cellW * fill, lay.chargeCellH);
+      ctx.restore();
     }
 
     // --- combo -------------------------------------------------------
@@ -926,7 +940,7 @@ export class Renderer {
     }
 
     // --- the question ------------------------------------------------
-    const gate = g.phase === "breakdown" ? g.reviveGate : g.activeGate;
+    const gate = g.activeGate;
     if (gate && gate.q && !gate.resolved && now >= gate.revealAt - 0.05) {
       const size = Math.min(u * 2.5, lay.area.w / (measureRich(ctx, gate.q.prompt, 100) / 100) * 0.86);
       const bw = measureRich(ctx, gate.q.prompt, size) + u * 2.4;
@@ -936,7 +950,7 @@ export class Renderer {
       ctx.fillStyle = "rgba(4,6,18,0.82)";
       this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
       ctx.fill();
-      ctx.strokeStyle = rgba(th.horizon, 0.55);
+      ctx.strokeStyle = rgba(th.horizon, PROMPT_STROKE_ALPHA);
       ctx.lineWidth = Math.max(1.5, u * 0.1);
       this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
       ctx.stroke();
@@ -946,11 +960,47 @@ export class Renderer {
         glowWidth: size * 0.4,
       }, true);
 
-      if (g.phase !== "breakdown") {
-        const remain = Math.max(0, Math.min(1, (gate.time - now) / 2.4));
-        ctx.fillStyle = rgba(th.horizon, 0.85);
-        ctx.fillRect(bx + u * 0.4, by + bh - u * 0.3, (bw - u * 0.8) * remain, u * 0.18);
+      const remain = Math.max(0, Math.min(1, (gate.time - now) / 2.4));
+      ctx.fillStyle = rgba(th.horizon, 0.85);
+      ctx.fillRect(bx + u * 0.4, by + bh - u * 0.3, (bw - u * 0.8) * remain, u * 0.18);
+
+      // RESTART THE HEART — the founder likes the phrase, and it survives. What
+      // does not survive is the modal it used to head: this is a BANNER over an
+      // ordinary gate, on a field that never stopped moving, and there is no
+      // scrim anywhere near the question. See `ink.ts` for the 2.30:1 that the
+      // scrim was costing.
+      if (gate.debt) {
+        const pulse = 0.5 + 0.5 * Math.sin(now * 5);
+        ctx.textAlign = "center";
+        ctx.font = font(u * 1.05, 900);
+        ctx.fillStyle = rgba(th.horizon, 0.72 + pulse * 0.28);
+        ctx.fillText("RESTART THE HEART", lay.cx, by - u * 0.85);
       }
+    }
+
+    // --- the completed sum, held --------------------------------------
+    // Accent colour, never red, and no deadline: `game-pacing`'s `revealPlan`
+    // gives `holdMs: Infinity` and only the child's own next note takes it down.
+    if (!gate && g.reveal) {
+      const r = g.reveal;
+      const text = `${r.prompt} = ${r.answer}`;
+      const size = Math.min(u * 2.2, (lay.area.w / Math.max(1, measureRich(ctx, text, 100) / 100)) * 0.8);
+      const bw = measureRich(ctx, text, size) + u * 2.4;
+      const bh = size * 2.3;
+      const bx = lay.cx - bw / 2;
+      const by = lay.promptY;
+      ctx.fillStyle = "rgba(4,6,18,0.82)";
+      this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
+      ctx.fill();
+      ctx.strokeStyle = rgba(th.horizon, PROMPT_STROKE_ALPHA);
+      ctx.lineWidth = Math.max(1.5, u * 0.1);
+      this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
+      ctx.stroke();
+      drawRich(ctx, text, lay.cx, by + bh / 2, size, {
+        fill: "#ffffff",
+        glow: rgba(th.horizon, 0.8),
+        glowWidth: size * 0.4,
+      }, true);
     }
 
     // --- timing meter ------------------------------------------------
@@ -995,34 +1045,6 @@ export class Renderer {
       ctx.fillStyle = rgba(th.horizon, 0.9);
       ctx.fillText(g.sector.name, lay.cx, this.playTop + this.playH / 2);
       ctx.globalAlpha = 1;
-    }
-
-    // --- breakdown overlay -------------------------------------------
-    if (g.phase === "breakdown" && g.reviveGate) {
-      ctx.fillStyle = "rgba(3,4,12,0.72)";
-      ctx.fillRect(0, 0, this.W, this.H);
-      const pulse = 0.5 + 0.5 * Math.sin(now * 5);
-      ctx.textAlign = "center";
-      ctx.font = font(u * 1.15, 900);
-      ctx.fillStyle = rgba(th.horizon, 0.7 + pulse * 0.3);
-      ctx.fillText("RESTART THE HEART", lay.cx, this.playTop - u * 1.2);
-
-      for (let l = 0; l < 3; l++) {
-        const y = this.laneY(l);
-        const c = LANE_COLOR[l]!;
-        const w = Math.min(lay.area.w * 0.82, u * 20);
-        const h = this.laneH * 0.78;
-        ctx.fillStyle = "rgba(7,10,24,0.95)";
-        this.roundRect(ctx, lay.cx - w / 2, y - h / 2, w, h, u * 0.6);
-        ctx.fill();
-        ctx.strokeStyle = rgba(c, 0.75 + pulse * 0.25);
-        ctx.lineWidth = Math.max(3, u * 0.24);
-        this.roundRect(ctx, lay.cx - w / 2, y - h / 2, w, h, u * 0.6);
-        ctx.stroke();
-        drawRich(ctx, g.reviveGate.labels[l]!, lay.cx, y, Math.min(h * 0.44, u * 2.6), {
-          fill: "#ffffff", glow: rgba(c, 0.9), glowWidth: u,
-        }, true);
-      }
     }
   }
 }

--- a/dynawalla/games/rhythm/src/stubHost.ts
+++ b/dynawalla/games/rhythm/src/stubHost.ts
@@ -310,8 +310,17 @@ export function createStubHost(opts: StubHostOptions = {}): Host & { log: readon
   return {
     log,
     next(o): Question {
-      const difficulty = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 1)));
-      let b = build(difficulty);
+      // `next({ difficulty })` speaks SPLITBEAT's 1..10 ladder — the scale
+      // `packs/shared/game-host` documents this game as sending — but the
+      // `Question.difficulty` handed BACK is a 0..1 position on the ladder,
+      // which is what the real host emits (`difficulty: Math.max(0,
+      // Math.min(1, ladder))`). This stub used to hand back the ladder index,
+      // so every question it served looked maximally hard to anything that read
+      // the field, and `answerPlan` — which sizes a child's reading time from
+      // exactly that field — could only ever be exercised at its ceiling here.
+      const rung = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 1)));
+      const difficulty = (rung - 1) / 9;
+      let b = build(rung);
       // Never offer a distractor equal to the answer, and never two identical
       // tiles — a duplicate tile is an unwinnable question.
       let guard = 0;
@@ -321,7 +330,7 @@ export function createStubHost(opts: StubHostOptions = {}): Host & { log: readon
           b = { ...b, wrong: uniq };
           break;
         }
-        b = build(difficulty);
+        b = build(rung);
       }
       counter += 1;
       return {


### PR DESCRIPTION
> "split beat - too hard … I'm a drummer and a mathematician and I can't last more than a few seconds really. It should be easier to start - and when you have to do a math problem to go on it should flow with the regular game and not be a reset. And we want to flex the continuous evolution and variability. Not start over into the same tune that you get tired of - continue into further evolution adapting the difficulty."

He is right on every count, and the numbers are worse than the report. Driven headlessly on a hand-turned audio clock, on `origin/main`:

| player | run ended at | times in 4 min | first question |
|---|---|---|---|
| watching, taps nothing | **3.14 s** | 74 | never reached one |
| moderate, 70% accurate | **44.46 s** | 16 | 12.69 s |

`charge` started at 5 and every unhit note took one. Notes land every 0.61 s at the opening. **A player who was merely watching was dead in three seconds — before the first question had ever appeared.** It was not possible to lose SPLITBEAT by playing badly, because it was not possible to reach anything to play badly at.

After this branch, same bots, same harness:

| player | heart first runs out | times in 4 min | first question | ends at |
|---|---|---|---|---|
| watching, taps nothing | **42.84 s** | 8, none a game over | **6.30 s** | lv 1.0 |
| moderate, 70% accurate | **never** | **0** | 5.91 s | lv 3.7 |
| expert, 100% accurate | never | 0 | 5.91 s | lv 10.0 |
| flailing, 15% + wrong answers | 42.22 s | 5, run intact throughout | 6.30 s | lv 1.0 |

---

## 1. The heart, not a countdown

`charge` was five integer blocks that only ever went down between questions. It is now a continuous meter that **refills as you play**: a landed note puts charge back, a missed one takes a little off, and a question puts a lot back.

- taps nothing → drains in ~43 s, and the first question arrives at 6.30 s, so a beginner **meets a question before they meet a consequence**
- lands half their notes → drifts by −0.003/s; survives indefinitely in practice
- lands 70% → net positive, stays full

The opening was also thinned to three notes per bar (1.15 notes/s at 92 BPM) — a half-time feel a beginner can physically follow — and the first question was pulled from bar 4 to bar 2.

The five blocks now fill **partially**, so the meter reads as something you are playing against rather than a countdown you cannot stop.

## 2. The failure state is no longer a reset

> "I don't like that it 'restarts' … it shouldn't take you back to the beginning … it should flow with the regular game and not be a reset."

`enterBreakdown()` did literally all of it: set a `phase` the planner refuses to plan in, `flushNotes()` to delete every note in flight, `tapeStop` on the mix, a modal over the field, and `reanchorSoft()` on the way out to re-seat the transport.

**The `"breakdown"` phase is deleted.** A phase you can enter and have to be let out of *is* the reset, however short. What happens now when the heart empties:

1. the music keeps playing, in tempo, with every note in flight intact;
2. a question is pulled forward to the next reveal — the toll, *"you have to do math to go on"*;
3. the world steps down, because whatever it was doing was too much;
4. the heart stops draining while the debt stands, so there is no spiral;
5. answering — **right or wrong** — clears it and the run continues from exactly where it was, evolved rather than rewound.

`RESTART THE HEART` survives as a **banner over an ordinary gate**, on a field that never stopped moving. The question is a normal gate: three tiles, in the three lanes, on the beat, with the full reading window.

Asserted by, among others, the strongest available observable: **every bar begins exactly where the one before it ended**, across a four-minute run of a player who bottoms out repeatedly. There is no way to restart a transport without opening a seam there.

## 3. Contrast on that screen — 2.30:1, and the cause was not a colour

> "the problem on 'restart the heart' doesn't have enough contrast"

Measured from the composite, per `games/balance/src/ink.ts`'s method. **Nobody had chosen a bad colour.** `drawHud` painted the question `#ffffff` inside an `rgba(4,6,18,0.82)` panel — **19.78:1**, one of the most legible surfaces in the pack — and thirty lines further down the breakdown overlay painted `rgba(3,4,12,0.72)` **over the whole canvas, question included**. The glyph composited to `rgb(74,74,80)` and its panel to `rgb(4,5,16)`: **2.30:1**, under both the 4.5:1 letterform bar and the 3.0:1 non-text bar.

The scrim is gone with the modal. The new `src/render/ink.ts` keeps the dead scrim as a constant *precisely so the test can measure what it did* and fail if anything puts it back.

Measuring the rest of the surface then found **a second, live defect nobody had reported**: the question panel's border, `rgba(th.horizon, 0.55)`, measured **2.68:1 in the violet sector**. Its sky bottom takes an additive bloom to `rgb(79,27,126)`, close enough to its own `rgb(214,150,255)` accent that the border almost vanishes. Raised to 0.9 → **4.57:1** worst case. Nobody would have found that by looking at indigo, which is where every run starts.

The panel's *fill* provably cannot carry that bar at any opacity — a near-black panel on a near-black sky is 1.01:1 and stays 1.02:1 at alpha 1.0 — so the border is load-bearing, and the test says so with a 256-step scan rather than a comment.

## 4. Difficulty comes DOWN when you are struggling

`adjustDifficulty` moved on a gate outcome and nothing else, so **a player who never survived to reach a gate never received one gram of relief** — the exact population the complaint is about.

SPLITBEAT now runs on `packs/shared/game-pacing`'s flow controller, with two channels:

- `gateSuccess` — how the maths is going
- `noteSuccess` — how the playing is going, a 24-note moving estimate

and it steers on the **worse of the two**, so struggling in either calms the world and climbing takes both. One scalar drives the maths difficulty, the tempo, the subdivision and the note count together, in both directions.

Measured: a 55%-accurate player who starts at difficulty 9 and **never once bottoms out** ends at 1.0. An expert climbs 1 → 10.

The intensity is also **persisted** (`memory.ts`, one small key). A child who kept struggling yesterday does not have to re-earn today's relief.

## 5. The answering window: pure, and monotone in the item

The hard constraint, and the seventeen-game defect from `PACING_AUDIT_2026-07.md`. SPLITBEAT had it twice.

**The reading lead** was `revealT0 + spb * 4 * (1 + inhaleBars)`, and `spb` is `60/bpm`. `READ_SEC = 6` was a floor under it, which stopped the collapse but did not make it monotone. Eight consecutive questions in a live run measured:

```
7.35  7.20  7.05  6.92  6.54  6.42  6.30  6.19    ← each one HARDER than the last
```

every one of them above the floor, every one of them shorter than the one before.

**The tile strike window** came from `windowsFor(spacing)` — a function of note spacing, which is a function of tempo. It happened to sit at the flat ±205 ms ceiling at every tempo this game reaches, so it was not misbehaving *yet*; "not currently broken" is not a property you can assert.

Both now come from `answerPlan(item)` in `src/game/answer.ts` — affine and **strictly increasing** in `Question.difficulty`, depending on the item and on nothing else:

| item difficulty | reading | strike |
|---|---|---|
| 0.00 | 6.00 s | ±300 ms |
| 0.25 | 6.88 s | ±363 ms |
| 0.50 | 7.75 s | ±425 ms |
| 0.75 | 8.63 s | ±488 ms |
| 1.00 | 9.50 s | ±550 ms |

Strictly increasing, not merely non-decreasing — "never less" is satisfied by a constant, and a constant is what the audit found everywhere.

**Delivered exactly, not approximately.** The naive way to spend a reading budget on a bar-quantised game is to round it up to whole bars, which puts `barDur` — the tempo — right back inside the delivered window. So the quantisation is spent on the *other* end: the gate stays on the grid (a drummer feels a downbeat coming) and the **reveal** is scheduled `readSec` before it, mid-bar if that is where it falls, because a reveal is a box of text and not a note. A four-minute run at 92→152 BPM delivers the plan to within 1e-6 s for every item.

## 6. Continuous evolution

`grooveBar` was seeded from the bar index, which sounds like variety and is not: `cells` only changed when a child answered with a musical denominator, so **a measured four-minute run produced ONE distinct bar shape, 222 times.** Lane 2 (HIGH) received **zero** notes at the opening — at `cells: 4` every slice is on-beat and only off-beat slices routed there — so the top third of the field was dead while the game killed you.

New `src/game/groove.ts`: a small mutable groove the transport advances one stochastic step per bar — rotation, accent period, subdivision — bounded so the world drifts rather than jumps. Notes are picked by **metric weight** (a groove is not a sprinkle, and a child can tell) under a **lane quota**: from three notes up, no lane may be empty. A drummer's hi-hat is the most constant voice in a beat, not the leftover.

Measured over four minutes: **21 distinct bar patterns for an expert, 18 for a moderate player, and no eight-bar phrase repeating even twice** — against ONE on main. The near-empty inhale bar, which used to be byte-identical every cycle and put both its notes in lane 0, now moves too.

The lane quota immediately found a live bug my own test caught: **a bar of 6 slices could only ever reach lanes 0 and 2** — six is a rung the evolution genuinely visits — because I had dropped the cyclic three-feel when rewriting lane assignment.

### Seam for `game-soundscape`

Another agent is building stochastic groove evolution into `packs/shared/game-soundscape` (PULSE is the proving ground). **I have not touched it.** The seam is `Groove` + `evolve(g, intensity)` in `src/game/groove.ts`: one mutable struct, one pure advance step, driven by the shared `[0,1]` intensity scalar and nothing else. Swapping `evolve` for the shared generator is a one-function change — `grooveBar` only reads `cells`, `accentEvery`, `phase` and `seed`.

### Also worth lifting to `packs/shared`

`src/render/ink.ts` and `games/balance/src/ink.ts` now both carry the same `luma` / `contrast` / `over` / `plus` and the same two bars. The generic half should move; I left it duplicated rather than touch `balance` on this branch.

---

## Verification

- `npm run -s tsc` clean; `npm run -s test` **70 → 110 tests, 5 consecutive runs, 0 failures**
- `node packs/build.mjs rhythm` builds and passes the SDK checker (49 modules, 122 KB, 3 files)
- every new assertion mutation-tested — see the transcript below

*(There is no `check` script — it prints nothing and exits 1, which looks exactly like a pass.)*

### Two bugs found by the tests, not by me

- **`laneOf` at 6 slices could only reach lanes 0 and 2.** The three-feel grid has only two slices on a beat, both downbeat-family, so lane 1 was unreachable — and 6 is a rung the evolution genuinely visits. Caught by the lane-quota sweep.
- **A debt raised while a question was already in flight was carried by no gate at all**, and `expireGate` — which cleared the debt only for a flagged gate — then left `heartDebt` stuck true for the rest of the run. Caught by the "owed question is an ordinary gate" test hanging.

### Three fixed while writing the tests

- The pack's dev `stubHost` returned `Question.difficulty` on the **1..10 ladder**, but the real host emits a 0..1 position (`game-host/index.ts:681`). Every stub question therefore looked maximally hard to anything reading the field — including `answerPlan`, which sizes a child's reading time from exactly that field.
- `noteTarget` clamped `max(3, min(cells, n))`, returning **three notes for a two-slice bar** — a target the caller would then have had to silently drop.
- A test that failed before reaching `game.destroy()` **hung the whole runner** rather than reporting, because `Game.start()` arms a `setInterval` that keeps node's event loop alive. Found when a mutation turned a 2-second run into a 4-minute timeout. All test-owned games now dispose via `using`.

### One assertion of mine that was wrong

The first draft of the scrim-calibration test asserted that a 50% dim over the question was unacceptable. Measured, it is **5.19:1** and genuinely fine. The cliff is between 0.5 and 0.6; what shipped was 0.72. The test now states where the cliff is, and says so in a comment.
