### PR TITLE
chore(dynawalla): 0.3.11

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.10 → 0.3.11. **25 packs.**

Six changes, and three of them fix a *class* with a gate rather than an instance.

## Classes

**#783 — the safe area, once, for the whole fleet.** The root cause was in the plumbing: `setHostInsets` was a plain assignment and `onInsetsChange` listened only for `resize`/`orientationchange` — so **the one path by which real insets reach a pack was the one path nothing was told about**. 10 of 25 packs were wrong, including ABYSSAL BLOOM's depth readout inside the 48px nav bar (which never mentioned the safe area, so no text search could have found it) and SPLITBEAT's 9 bare `env()`s in a module the test runner refuses to import. The new gate parses each pack's shipped CSS with `env()` defined as **zero**, at 10 viewports — no substring searches. Cross-checked: **2350 Chromium probes, 0 disagreements**, with a negative control.

**#781 — a retired pack is uninstalled at the next launch.** A tombstone ledger compiled into the binary; `remove_retired` joins each named id onto the pack root and **never enumerates the directory**, so a downloaded pack is structurally unreachable from it. Found in passing: **no workflow in this repo ran `cargo test`**, so #749's guard against deleting every downloaded pack had never once executed on a PR.

**#780 — the groove evolves, and a level transition turns the key over.** The static rhythm was not the groove at all: the bass was `BASS_PATTERNS[tier]`, a written array, one pattern every bar forever. PULSE: **1 distinct bass bar in 64 → 36.1**. Mode rotation on `session.transition` — the old rule protected a *reason* (no unbidden change mid-question), and a transition is bidden.

## Games

**#784 SPLITBEAT** — a player who taps nothing died at **3.14s, 74 times in four minutes, without ever seeing a question**. It was not possible to lose by playing badly because you could not reach anything to play badly at. The heart is a maths toll now, the run never restarts, and the answering window is a pure, strictly increasing function of the item — on main, eight consecutive questions got 7.35s → 6.19s, each harder and each given less time.

**#782 THE LATTICE** — "no resonator" was `HINT_BAND` from #735, the **third** game that change broke, and it deadlocked: only a report moves the ladder, only a resonator produces a report. 3600 of 3600 frames showed the stall notice on a fresh profile.

**#782 LATTICE RUNNER → THE TUNING HALL** — 8 hulls to 2, and escalation was a **clock**: sitting still for 90s raised item difficulty from 2 to 7.

**#779 GUILTY / COIL** — crystal numerals 1.04:1 → 17.93:1; a death screen rendering 483px wide on a 393px phone; and COIL's own rule, `SHEAR OFF THE LIT NUMBER`, at **2.45:1**.

A main push does not release. The tag `dynawalla-v0.3.11` does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb