### PR TITLE
docs: require prompt merged-worktree cleanup

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -58,7 +58,8 @@ wt_count="$(git worktree list 2>/dev/null | wc -l | tr -d ' ')"
 nested="$(git worktree list 2>/dev/null | awk '{print $1}' | grep -c "^${primary}/")"
 if [ "${wt_count:-0}" -gt 12 ]; then
   printf '  ! %s registered worktrees (%s nested inside the repo).\n' "${wt_count}" "${nested}"
-  printf '    Prune yours when the PR merges: git worktree remove <path> && git worktree prune\n'
+  printf '    Prune yours when its PR merges, after the trunk-pr skill section 11 preflight.\n'
+  printf '    Never force-remove a worktree; ignored local state can look clean.\n'
 fi
 printf '  new worktrees go OUTSIDE the repo: %s/<branch>\n' "${wt_root}"
 

--- a/.claude/skills/trunk-pr/FAILURE-MODES.md
+++ b/.claude/skills/trunk-pr/FAILURE-MODES.md
@@ -34,15 +34,14 @@ version is narrower than the scary one:
 | Action | Result |
 | --- | --- |
 | `git worktree remove <path>` | **Refuses.** `fatal: '<path>' contains modified or untracked files, use --force to delete it` |
+| `git worktree remove <path>` with only ignored files | **Destroys the ignored files.** Ordinary status does not show them |
 | `git worktree remove --force <path>` | **Destroys it.** No reflog, no dangling object |
 | Claude Code's periodic worktree sweep | **Skips it.** The sweep "skips a worktree that still holds work: changed or untracked files, or unpushed commits", and never touches worktrees you made with `--worktree` |
 
-So git and the sweep both defend you, and the loss vector is narrower than
-"pruning deletes your work". What remains is still real: `--force` is precisely
-what someone reaches for *when the plain remove fails*, and the work has no
-backup anywhere — not in a ref, not in a stash, not in the object store. Any
-`git clean -fdx`, disk loss, or impatient `--force` ends it, and nothing warns
-you first because as far as git is concerned there is nothing there.
+Git and the sweep defend visible untracked work, but ignored files remain at
+risk and `--force` bypasses the visible-file guard. This work has no backup
+anywhere — not in a ref, stash, or the object store. Any `git clean -fdx`, disk
+loss, ordinary removal of ignored-only state, or impatient `--force` ends it.
 
 **Why invisible.** `git log --all`, `git branch -a`, `git stash list` and
 `git fsck --lost-found` all search *objects*. Untracked files are not objects.
@@ -52,13 +51,17 @@ Every one of those commands answers "nothing here" and is correct.
 
 ```bash
 git worktree list --porcelain | grep '^worktree' | cut -d' ' -f2 | while read -r d; do
-  n=$(git -C "$d" status --porcelain | wc -l)
+  n=$(git -C "$d" status --porcelain --ignored=matching --untracked-files=normal | wc -l)
   [ "$n" -gt 0 ] && printf '%-60s %s dirty/untracked\n' "$d" "$n"
 done
 ```
 
-**Never** `git worktree remove` a worktree whose `git status --porcelain` is
-non-empty without reading what is in it first.
+**Never** `git worktree remove` a worktree whose
+`git status --porcelain --ignored=matching --untracked-files=normal` is non-empty
+without recursively reading the reported roots first and distinguishing
+regenerable build output from local state. `matching` avoids enumerating every
+file in enormous ignored `target/` and `node_modules/` trees; explicit `normal`
+keeps the result independent of `status.showUntrackedFiles`.
 
 ### A2. A stalled agent leaves finished work uncommitted, or committed and unpushed
 
@@ -75,7 +78,7 @@ newer commit existed.
 **Guard.** When an agent dies, **inspect its worktree before believing its PR**:
 
 ```bash
-git -C "$WT" status --porcelain                       # uncommitted?
+git -C "$WT" status --porcelain --untracked-files=all # uncommitted?
 git -C "$WT" rev-list --count @{u}..HEAD               # committed, unpushed?
 git -C "$WT" rev-list --count HEAD..@{u}               # diverged from what you pushed?
 git -C "$WT" diff origin/main HEAD -- <its paths>      # what does it have that main lacks?
@@ -332,14 +335,10 @@ cd "$WT" && gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
 
 ## Postflight
 
-After the merge:
-
-```bash
-git -C "$REPO" fetch origin
-git -C "$REPO" merge --ff-only origin/main     # refuses ⇒ investigate, never force
-git -C "$REPO" status --porcelain              # must be empty
-git -C "$REPO" worktree remove "$WT"           # only after checking it is clean (A1)
-```
+After the merge, follow the deletion preflight and explicit-path cleanup in
+[`SKILL.md` §11](SKILL.md#11-prove-the-work-is-safe-then-clean-up-immediately).
+It checks tracked, untracked, ignored, unpushed, divergent, and post-merge work
+before removing the worktree.
 
 `--ff-only` is the invariant, expressed as a command. If it refuses, something
 wrote to the primary checkout, and that is the incident — not the refusal.

--- a/.claude/skills/trunk-pr/HARNESS.md
+++ b/.claude/skills/trunk-pr/HARNESS.md
@@ -244,10 +244,11 @@ common=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null) || exit 0
 findings=""
 while read -r d; do
   [ -d "$d" ] || continue
-  dirty=$(git -C "$d" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  dirty=$(git -C "$d" status --porcelain --ignored=matching \
+    --untracked-files=normal 2>/dev/null | wc -l | tr -d ' ')
   unpushed=$(git -C "$d" rev-list --count @{u}..HEAD 2>/dev/null || echo 0)
   [ "$dirty" = "0" ] && [ "${unpushed:-0}" = "0" ] && continue
-  findings="${findings}  ${d}: ${dirty} uncommitted, ${unpushed} unpushed\n"
+  findings="${findings}  ${d}: ${dirty} local paths/ignored roots, ${unpushed} unpushed\n"
 done < <(git -C "$cwd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
 [ -n "$findings" ] && printf 'WORK NOT ON THE REMOTE:\n%b' "$findings" >&2
 exit 0

--- a/.claude/skills/trunk-pr/SKILL.md
+++ b/.claude/skills/trunk-pr/SKILL.md
@@ -166,7 +166,7 @@ Conventional commit, imperative, honest. No emoji.
 
 ```bash
 git -C "$WT" add -A
-git -C "$WT" status --porcelain     # confirm exactly what you intend
+git -C "$WT" status --porcelain --untracked-files=all # confirm exactly what you intend
 git -C "$WT" commit -m "fix(catalog): dedupe entries by id before install"
 git -C "$WT" push -u origin "$BR"
 ```
@@ -215,14 +215,130 @@ git -C "$WT" merge origin/main       # or rebase; keep it small and current
 git -C "$WT" push
 ```
 
-## 11. Fast-forward local main, then clean up
+## 11. Prove the work is safe, then clean up immediately
+
+After GitHub confirms the PR was squash-merged, verify the worktree before
+deleting anything. Only the worktree's owning agent may run this, after every
+build, dev server, emulator, and other process using it has exited. Run the
+block from anywhere inside the worktree being removed:
 
 ```bash
+set -euo pipefail
+WT="$(git rev-parse --show-toplevel)"
+COMMON_DIR_RAW="$(git -C "$WT" rev-parse --git-common-dir)"
+COMMON_DIR="$(cd "$WT" && cd "$COMMON_DIR_RAW" && pwd -P)"
+REPO="$(dirname "$COMMON_DIR")"
+BR="$(git -C "$WT" branch --show-current)"
+test "$WT" != "$REPO"
+test -n "$BR"
+ORIGIN_URL="$(git -C "$REPO" remote get-url origin)"
+PUSH_URL="$(git -C "$REPO" remote get-url --push origin)"
+case "$ORIGIN_URL" in
+  https://github.com/corpora-inc/encorpora|https://github.com/corpora-inc/encorpora.git|\
+  git@github.com:corpora-inc/encorpora|git@github.com:corpora-inc/encorpora.git) ;;
+  *) printf 'unexpected origin URL; refusing cleanup\n' >&2; exit 1 ;;
+esac
+case "$PUSH_URL" in
+  https://github.com/corpora-inc/encorpora|https://github.com/corpora-inc/encorpora.git|\
+  git@github.com:corpora-inc/encorpora|git@github.com:corpora-inc/encorpora.git) ;;
+  *) printf 'unexpected push URL; refusing cleanup\n' >&2; exit 1 ;;
+esac
 git -C "$REPO" fetch origin
-git -C "$REPO" merge --ff-only origin/main
+PRIMARY_BRANCH="$(git -C "$REPO" branch --show-current)"
+PRIMARY_STATUS="$(git -C "$REPO" status --porcelain --untracked-files=all)"
+PRIMARY_OID="$(git -C "$REPO" rev-parse HEAD)"
+ORIGIN_MAIN_OID="$(git -C "$REPO" rev-parse origin/main)"
+WT_BRANCH="$(git -C "$WT" branch --show-current)"
+BRANCH_OID="$(git -C "$WT" rev-parse "refs/heads/$BR")"
+HEAD_OID="$(git -C "$WT" rev-parse HEAD)"
+WT_STATUS="$(git -C "$WT" status --porcelain --untracked-files=all)"
+NESTED_WTS="$(git -C "$REPO" worktree list --porcelain | \
+  awk -v prefix="$WT/" '/^worktree / { path=substr($0, 10); \
+    if (index(path, prefix) == 1) print path }')"
+IGNORED_ROOTS="$(git -C "$WT" status --short --ignored=matching \
+  --untracked-files=normal)"
+printf '%s\n' "$IGNORED_ROOTS"
+PR_JSON="$(gh pr view "$BR" --repo corpora-inc/encorpora \
+  --json state,mergedAt,baseRefName,headRefName,headRefOid)"
+PR_STATE="$(jq -er .state <<<"$PR_JSON")"
+PR_MERGED_AT="$(jq -er .mergedAt <<<"$PR_JSON")"
+PR_BASE="$(jq -er .baseRefName <<<"$PR_JSON")"
+PR_HEAD="$(jq -er .headRefName <<<"$PR_JSON")"
+PR_HEAD_OID="$(jq -er .headRefOid <<<"$PR_JSON")"
+REMOTE_OID="$(git -C "$REPO" ls-remote --heads origin "refs/heads/$BR" | \
+  awk 'NR == 1 { print $1 }')"
+test "$PRIMARY_BRANCH" = main
+test -z "$PRIMARY_STATUS"
+git -C "$REPO" merge-base --is-ancestor "$PRIMARY_OID" "$ORIGIN_MAIN_OID"
+test "$WT_BRANCH" = "$BR"
+test "$BRANCH_OID" = "$HEAD_OID"
+test -z "$WT_STATUS"
+test -z "$NESTED_WTS"
+test "$PR_STATE" = MERGED
+test -n "$PR_MERGED_AT"
+test "$PR_BASE" = main
+test "$PR_HEAD" = "$BR"
+test "$PR_HEAD_OID" = "$HEAD_OID"
+test -z "$REMOTE_OID" || test "$REMOTE_OID" = "$HEAD_OID"
+if test -n "$IGNORED_ROOTS"; then
+  printf 'Preserve local state, explicitly remove only verified regenerable !! roots, then rerun.\n' >&2
+  exit 1
+fi
+git -C "$REPO" merge --ff-only --no-overwrite-ignore "$ORIGIN_MAIN_OID"
+FINAL_PRIMARY_BRANCH="$(git -C "$REPO" branch --show-current)"
+FINAL_PRIMARY_STATUS="$(git -C "$REPO" status --porcelain --untracked-files=all)"
+FINAL_PRIMARY_OID="$(git -C "$REPO" rev-parse HEAD)"
+FINAL_WT_BRANCH="$(git -C "$WT" branch --show-current)"
+FINAL_BRANCH_OID="$(git -C "$WT" rev-parse "refs/heads/$BR")"
+FINAL_HEAD_OID="$(git -C "$WT" rev-parse HEAD)"
+FINAL_WT_STATUS="$(git -C "$WT" status --porcelain --untracked-files=all)"
+FINAL_NESTED_WTS="$(git -C "$REPO" worktree list --porcelain | \
+  awk -v prefix="$WT/" '/^worktree / { path=substr($0, 10); \
+    if (index(path, prefix) == 1) print path }')"
+test "$FINAL_WT_BRANCH" = "$BR"
+test "$FINAL_PRIMARY_BRANCH" = main
+test -z "$FINAL_PRIMARY_STATUS"
+test "$FINAL_PRIMARY_OID" = "$ORIGIN_MAIN_OID"
+test "$FINAL_BRANCH_OID" = "$HEAD_OID"
+test "$FINAL_HEAD_OID" = "$HEAD_OID"
+test -z "$FINAL_WT_STATUS"
+test -z "$FINAL_NESTED_WTS"
+FINAL_IGNORED_ROOTS="$(git -C "$WT" status --short --ignored=matching \
+  --untracked-files=normal)"
+test -z "$FINAL_IGNORED_ROOTS"
 git -C "$REPO" worktree remove "$WT"
+git -C "$REPO" update-ref -d "refs/heads/$BR" "$HEAD_OID"
+if test -n "$REMOTE_OID"; then
+  git -C "$REPO" push --force-with-lease="refs/heads/$BR:$HEAD_OID" \
+    "$PUSH_URL" ":refs/heads/$BR"
+fi
 git -C "$REPO" worktree prune
+git -C "$REPO" fetch --prune origin
 ```
 
-`--ff-only` is deliberate: if it refuses, the primary checkout has commits of
-its own, which means rule 0 was broken. Investigate; do not force it.
+Run that block as one shell invocation; do not split it across tool calls. The
+tests fail closed unless the primary is a clean `main`, the worktree is a clean
+checkout of exactly `$BR` with no nested registered worktrees, that exact head
+was merged into `main` in the canonical GitHub repository, and the remote branch
+is absent or still names that head. Explicit `--untracked-files=all` (or the
+bounded ignored-root listing's explicit `normal`) overrides local status
+configuration. The expected-OID local deletion and remote lease preserve a ref
+if another agent advances it during cleanup.
+The bounded ignored-root listing avoids walking millions of build artifacts,
+but cleanup refuses to remove a worktree while any ignored state remains. Stop
+all writers, recursively inspect every `!!` root, preserve non-regenerable local
+config, credentials, databases, signing material, or nested work elsewhere,
+then explicitly remove only verified regenerable output and rerun the block.
+Ordinary `git status` hides ignored state. If any command or test fails, stop
+and inspect the diff, log, and files; commit and push useful work on the existing
+branch or a recovery branch. Never force-remove it.
+
+The ancestry check rejects a primary `main` that is ahead or divergent;
+`--ff-only --no-overwrite-ignore` then advances a behind primary to the exact
+fetched `origin/main` OID without replacing ignored primary files. If either
+refuses, investigate; do not force it.
+Remote deletion uses the validated literal push URL and an explicit lease, so
+extra configured push URLs cannot receive the deletion and a concurrent push
+stops cleanup instead of deleting new work. Cleanup is part of Done; never leave
+a merged worktree holding a Rust `target/`, `node_modules/`, app bundle, or
+other regenerable build output. Only remove your own worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,17 @@ and `needs-human` (the rare item parked for the device/CDP sweep). That's it.
 6. **Auto-merge.** Enable it (`gh pr merge --squash --auto`). When every required
    check is green, the **merge queue** integrates the latest `main`, re-runs checks,
    and merges with **no human in the path**. The issue moves to Done.
-7. **Fast-forward your local `main`** (`git fetch origin && git merge --ff-only`),
-   delete the branch and its worktree, and pull the next issue.
+7. **Clean up immediately after merge.** Cleanup is part of Done: never leave a
+   merged worktree holding `target/`, `node_modules/`, app bundles, or other
+   regenerable build output. Follow the exact deletion preflight and cleanup in
+   [the trunk PR procedure](.claude/skills/trunk-pr/SKILL.md#11-prove-the-work-is-safe-then-clean-up-immediately).
+   It proves the current head was merged, checks tracked, untracked, ignored,
+   unpushed, and divergent work, fast-forwards the clean primary `main`, then
+   removes the worktree and prunes its branches and metadata.
+
+   Only clean up your own worktree, and never force-remove one. If the PR is
+   unmerged or a preflight check fails, inspect and preserve useful work on its
+   branch or a clearly named recovery branch, or ask the owner.
 
 ## The gates (what green means)
 


### PR DESCRIPTION
## What

Make prompt cleanup part of the worker definition of Done and replace unchecked
removal advice with one fail-closed post-merge procedure.

## Why

Merged worktrees retain large duplicated Rust targets and Node dependencies.
Cleanup must free that space without deleting dirty, unpushed, ignored, nested,
divergent, or otherwise unmerged work.

## Blast radius

**Areas touched:** docs / shared agent control plane

- [x] No product, pack, native, curriculum, secret, or release behavior changed.
- [x] The advisory SessionStart hook points to the guarded procedure instead of
  advertising unchecked removal.
- [x] The procedure validates the canonical fetch and push URLs, exact merged PR
  identity/head, local and remote expected OIDs, primary/worktree state, nested
  worktrees, and ignored roots before deletion.

## Proof

```text
git diff --check
# exit 0

bash -n .claude/hooks/worktree-guard.sh
# exit 0

sed -n '226,316p' .claude/skills/trunk-pr/SKILL.md | bash -n
# exit 0

git -c status.showUntrackedFiles=no status --porcelain --untracked-files=all
# explicitly reported changes despite the local override

git -c status.showUntrackedFiles=no status --short --ignored=matching --untracked-files=normal
# explicitly reported ignored/untracked roots despite the local override

git push --dry-run --force-with-lease="refs/heads/$BR:$HEAD_OID" "$PUSH_URL" ":refs/heads/$BR"
# validated leased deletion syntax without mutating the remote
```

The primary checkout's existing untracked files were preserved and never edited.

## Codex adversarial review

`encorpora` does not contain `./bin/codex-review.sh`. I ran the standard wrapper
from the adjacent tuzi repository while inside this worktree, so it reviewed
`origin/main...HEAD`; this provenance difference is disclosed rather than
silently skipped.

The final capped pass reviewed `4d0627e76` and returned the following verbatim:

```text
No live-service, balance, authentication, deployment, or Kubernetes code changes. The blast radius is local developer data loss, leaked credentials, and blocked shipping.

1. `.claude/skills/trunk-pr/SKILL.md:287` — Severity: MEDIUM. Confidence: HIGH. The primary checkout is checked only with ordinary status, which hides ignored files. `git merge` defaults to `--overwrite-ignore`. The current primary already contains an ignored `.env` and numerous ignored build trees. If `origin/main` begins tracking any colliding path, the fast-forward silently overwrites that local ignored state. A local environment or credential file can disappear even though this procedure claims to prove cleanup is safe. Use `--no-overwrite-ignore` or inspect primary ignored paths before merging.

2. `.claude/skills/trunk-pr/SKILL.md:309` — Severity: MEDIUM. Confidence: MEDIUM. There is a time-of-check/time-of-use window after the final ignored-file scan. If a supposedly stopped dev server, database, TTS pipeline, or compiler writes an ignored file after line 308, `git worktree remove` treats the tree as clean and recursively deletes that file without warning. A late SQLite write or pipeline-state update is then lost permanently; no Git object or reflog can recover it. “All processes have exited” is stated but not enforced.

3. `.claude/skills/trunk-pr/SKILL.md:239` — Severity: MEDIUM. Confidence: MEDIUM. The rejection path prints the complete unexpected remote URL; line 244 does the same for the push URL. If a worker clone embeds a PAT in an HTTPS URL, the safety check rejects it and writes the live credential into the agent/session log. The current clone uses a credential-free URL, but the procedure is intended for every worker environment.

4. `.claude/skills/trunk-pr/SKILL.md:226` — Severity: LOW. Confidence: HIGH. CI does not execute or semantically validate this cleanup program. `.claude/**` and Markdown are explicitly gate-exempt, so `ci-gate` can remain green with broken Git/GitHub commands. A regression that makes the block abort after every merge leaves 50–150 GiB build worktrees accumulating until disk exhaustion blocks builds or an urgent production fix. The block passes `bash -n` locally, but syntax alone does not exercise merged-PR lookup, ignored-file handling, or lease-protected deletion.

RISKIEST LINE: `.claude/skills/trunk-pr/SKILL.md:309` — it performs the irreversible recursive deletion and depends on every preceding visibility and process-quiescence assumption being true.
```

Findings 1 and 3 were fixed in `76024d40a`: the pinned primary fast-forward now
uses `--no-overwrite-ignore`, and unexpected URLs are rejected without echoing
their potentially credential-bearing values. The earlier multiple-push-URL
blocker is fixed by pushing the leased deletion to the validated literal
`$PUSH_URL`, never to the remote name.

Finding 2 is an inherent Git/filesystem race rather than fully atomically
enforceable by this runbook. The procedure mitigates it by allowing only the
owning agent, requiring all writers to stop, refusing any ignored state, and
placing a second zero-ignored-state check immediately before ordinary (never
forced) removal. The finding remains disclosed rather than overstating safety.
Finding 4 is the disclosed CI coverage gap; the executable block was syntax
checked locally and its leased literal-URL deletion was dry-run successfully.
